### PR TITLE
Add datascript as a data cache

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,8 @@
                  [prismatic/om-tools "0.3.11"]
                  [inflections "0.9.14"]
                  [prismatic/schema "0.4.3"]
-                 [secretary "1.2.3"]]
+                 [secretary "1.2.3"]
+                 [datascript "0.11.6"]]
 
   :plugins [[lein-cljsbuild "1.0.5"]
             [lein-figwheel "0.3.5"]
@@ -31,7 +32,8 @@
                                    :asset-path "js/compiled/out-ui"
                                    :output-to "resources/public/js/compiled/witan-ui.js"
                                    :output-dir "resources/public/js/compiled/out-ui"
-                                   :source-map-timestamp true }}
+                                   :source-map-timestamp true
+                                   :warnings {:single-segment-namespace false}}}
                        {:id "login"
                         :source-paths ["src"]
                         :figwheel true

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,8 @@
 
   :plugins [[lein-cljsbuild "1.0.5"]
             [lein-figwheel "0.3.5"]
-            [lein-garden "0.2.6"]]
+            [lein-garden "0.2.6"]
+            [lein-cljfmt "0.3.0"]]
 
   :source-paths ["src"]
 

--- a/src/witan/login/core.cljs
+++ b/src/witan/login/core.cljs
@@ -1,7 +1,7 @@
 (ns witan.login.core
-  (:require[om.core :as om :include-macros true]
-           [om-tools.core :refer-macros [defcomponentmethod]]
-           [sablono.core :as html :refer-macros [html]]))
+  (:require [om.core :as om :include-macros true]
+            [om-tools.core :refer-macros [defcomponentmethod]]
+            [sablono.core :as html :refer-macros [html]]))
 
 (defonce app-state (atom {:state :prompt}))
 (def ls ;;login-strings

--- a/src/witan/schema/core.cljc
+++ b/src/witan/schema/core.cljc
@@ -29,5 +29,4 @@
    (s/required-key :last-modifier) s/Str
    (s/optional-key :descendant-id) ProjectionIdType
    ;; added internally
-   (s/optional-key :db/id)         s/Int
-   (s/optional-key :has-ancestors) s/Bool})
+   (s/optional-key :db/id)         s/Int})

--- a/src/witan/schema/core.cljc
+++ b/src/witan/schema/core.cljc
@@ -6,6 +6,7 @@
   #{:event/test-event            ;; this event is purely for testing
     :event/select-projection     ;; indicates that a projection is currently selected
     :event/toggle-tree-view      ;; indicates that the projection tree should expand at the specified branch
+    :event/filter-projections    ;; filter the projections by name
     })
 
 (def ProjectionTypes

--- a/src/witan/schema/core.cljc
+++ b/src/witan/schema/core.cljc
@@ -4,8 +4,9 @@
 (def Events
   "Any control events should be included here"
   #{:event/test-event            ;; this event is purely for testing
-    :event/select-projection}    ;; indicates that a projection is currently selected
-  )
+    :event/select-projection     ;; indicates that a projection is currently selected
+    :event/toggle-tree-view      ;; indicates that the projection tree should expand at the specified branch
+    })
 
 (def ProjectionTypes
   "Valid Projection types"
@@ -19,11 +20,15 @@
 
 (def Projection
   "A schema for a schema"
-  {:id ProjectionIdType
-   :name s/Str
-   :type ProjectionTypes
-   :owner s/Str
-   :version s/Int
-   :last-modified s/Str
-   :last-modifier s/Str
-   :previous-version (s/maybe (s/recursive #'Projection))})
+  {(s/required-key :id)            ProjectionIdType
+   (s/required-key :name)          s/Str
+   (s/required-key :type)          ProjectionTypes
+   (s/required-key :owner)         s/Str
+   (s/required-key :version)       s/Int
+   (s/required-key :last-modified) s/Str
+   (s/required-key :last-modifier) s/Str
+   (s/optional-key :descendant-id) ProjectionIdType
+   ;; added internally
+   (s/optional-key :db/id)         s/Int
+   (s/optional-key :has-ancestors) s/Bool
+   })

--- a/src/witan/schema/core.cljc
+++ b/src/witan/schema/core.cljc
@@ -30,5 +30,4 @@
    (s/optional-key :descendant-id) ProjectionIdType
    ;; added internally
    (s/optional-key :db/id)         s/Int
-   (s/optional-key :has-ancestors) s/Bool
-   })
+   (s/optional-key :has-ancestors) s/Bool})

--- a/src/witan/styles/base.clj
+++ b/src/witan/styles/base.clj
@@ -9,147 +9,141 @@
 (defstyles base
   (-> (concat
         ;; fonts
-        f/font-face-definitions
+       f/font-face-definitions
 
         ;; style
-        [
-         ;; tags
-         [:html
-          {:background-color colour/bg}]
-         [:body
-          {}]
-         [:body :h1 :h2 :h3 :h4 :h5
-          {:font-family f/base-fonts}]
-         [:h1
-          {:color colour/title}]
-         [:h2
-          {:color colour/subtitle}]
-         [:h3
-          {:color colour/para-heading}]
-         [:hr
-          {:color colour/hr
-           :background-color colour/hr}]
-         [:href
-          {:margin (px 0)
-           :padding (px 0)}]
+       [;; tags
+        [:html
+         {:background-color colour/bg}]
+        [:body
+         {}]
+        [:body :h1 :h2 :h3 :h4 :h5
+         {:font-family f/base-fonts}]
+        [:h1
+         {:color colour/title}]
+        [:h2
+         {:color colour/subtitle}]
+        [:h3
+         {:color colour/para-heading}]
+        [:hr
+         {:color colour/hr
+          :background-color colour/hr}]
+        [:href
+         {:margin (px 0)
+          :padding (px 0)}]
 
          ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
          ;; overrides
-         [:.pure-menu-heading
-          {:color colour/menu-item
-           :font-size (px 20)}]
-         [:.pure-menu
-          {:position :relative}
-          [:.pure-menu-list
-           {:position :absolute
-            :right (em 0.3)
-            :margin-top (em 0.3)}]]
-         [:.pure-table
-          [:thead
-           {:background-color :transparent
-            :border (px 0)}]]
+        [:.pure-menu-heading
+         {:color colour/menu-item
+          :font-size (px 20)}]
+        [:.pure-menu
+         {:position :relative}
+         [:.pure-menu-list
+          {:position :absolute
+           :right (em 0.3)
+           :margin-top (em 0.3)}]]
+        [:.pure-table
+         [:thead
+          {:background-color :transparent
+           :border (px 0)}]]
 
          ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-         [:.button-success
-          {:background-color colour/button-success
-           :color colour/white}]
+        [:.button-success
+         {:background-color colour/button-success
+          :color colour/white}]
 
-         [:.button-warning
-          {:background-color colour/button-warning
-           :color colour/white}]
+        [:.button-warning
+         {:background-color colour/button-warning
+          :color colour/white}]
 
-         [:.button-error
-          {:background-color colour/button-error
-           :color colour/white}]
+        [:.button-error
+         {:background-color colour/button-error
+          :color colour/white}]
 
-         [:.button-primary
-          {:background-color colour/button-primary
-           :color colour/white}]
+        [:.button-primary
+         {:background-color colour/button-primary
+          :color colour/white}]
 
-         [:.text-center
-          {:text-align :center}]
+        [:.text-center
+         {:text-align :center}]
 
-         [:.text-white
-          {:color colour/white}]
+        [:.text-white
+         {:color colour/white}]
 
          ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-         [:#container
-          {:margin (em 1)}]
+        [:#container
+         {:margin (em 1)}]
 
          ;; witan
-         [:#witan-menu :.witan-menu-link
-          {:transition "all 0.2s ease-out 0s"}]
+        [:#witan-menu :.witan-menu-link
+         {:transition "all 0.2s ease-out 0s"}]
 
-         [:#witan-menu
-          {:background-color colour/header
-           :box-shadow "0px 1px 3px rgba(0, 0, 0, 1)"}]
+        [:#witan-menu
+         {:background-color colour/header
+          :box-shadow "0px 1px 3px rgba(0, 0, 0, 1)"}]
 
-         [:.witan-menu-item
-          [:a
-           {:text-decoration :none
-            :color colour/menu-item
-            }]
-          [:a:hover
-           {:color colour/menu-item-hover}]]
+        [:.witan-menu-item
+         [:a
+          {:text-decoration :none
+           :color colour/menu-item}]
+         [:a:hover
+          {:color colour/menu-item-hover}]]
 
-         [:.witan-search-input
-          {:position :relative}
-          [:i
-           {:position :absolute
-            :vertical-align :middle
-            :margin (em 0.5)}]
-          [:#filter-input
-           {:padding-left (px 30)
-            }]]
+        [:.witan-search-input
+         {:position :relative}
+         [:i
+          {:position :absolute
+           :vertical-align :middle
+           :margin (em 0.5)}]
+         [:#filter-input
+          {:padding-left (px 30)}]]
 
-         [:.witan-dash-heading
-          {:color colour/primary
-           :font-size (px 20)
-           :border-bottom "#ccc 2px solid"}
-          [:h1
-           {:margin-bottom (em 0.2)
-            :font-size (em 2)
-            :display :inline-block}]
-          [:button
-           {:margin-left (em 0.5)}]
-          [:.pure-menu-list
-           {:bottom (em 0.55)}]
-          [:.pure-form
-           {:display :inline-flex
-            :font-size (px 14)
-            :vertical-align :text-bottom
-            :margin-left (em 1)}]]
+        [:.witan-dash-heading
+         {:color colour/primary
+          :font-size (px 20)
+          :border-bottom "#ccc 2px solid"}
+         [:h1
+          {:margin-bottom (em 0.2)
+           :font-size (em 2)
+           :display :inline-block}]
+         [:button
+          {:margin-left (em 0.5)}]
+         [:.pure-menu-list
+          {:bottom (em 0.55)}]
+         [:.pure-form
+          {:display :inline-flex
+           :font-size (px 14)
+           :vertical-align :text-bottom
+           :margin-left (em 1)}]]
 
-         [:#witan-main-content
-          {:padding-left (px 30)
-           :padding-right (px 30)}]
+        [:#witan-main-content
+         {:padding-left (px 30)
+          :padding-right (px 30)}]
 
-         [:#witan-dash-projection-list
-          {:width (percent 100)
-           :border (px 0)}
-          [:th :td
-           {:border (px 0)}]
-          [:th:first-child
-           {:width (px 1)}]]
+        [:#witan-dash-projection-list
+         {:width (percent 100)
+          :border (px 0)}
+         [:th :td
+          {:border (px 0)}]
+         [:th:first-child
+          {:width (px 1)}]]
 
-         [:.witan-projection-table-row
-          [:.modifier
-           {:color colour/gray
-            :margin-left (em 0.5)}]
-          [:.tree-control
-           {:background-color colour/white}]]
+        [:.witan-projection-table-row
+         [:.modifier
+          {:color colour/gray
+           :margin-left (em 0.5)}]
+         [:.tree-control
+          {:background-color colour/white}]]
 
-         [:.witan-projection-table-row:hover
-          {:background-color colour/row-highlight
-           :cursor :pointer}]
+        [:.witan-projection-table-row:hover
+         {:background-color colour/row-highlight
+          :cursor :pointer}]
 
-         [:.witan-projection-table-row-selected
-          :.witan-projection-table-row-selected:hover
-          {:background-color colour/row-selected}]
-
-
-         ])
+        [:.witan-projection-table-row-selected
+         :.witan-projection-table-row-selected:hover
+         {:background-color colour/row-selected}]])
       vec))

--- a/src/witan/styles/base.clj
+++ b/src/witan/styles/base.clj
@@ -148,5 +148,8 @@
 
          [:.witan-projection-table-row-selected
           :.witan-projection-table-row-selected:hover
-          {:background-color colour/row-selected}]])
+          {:background-color colour/row-selected}]
+
+
+         ])
       vec))

--- a/src/witan/styles/base.clj
+++ b/src/witan/styles/base.clj
@@ -145,5 +145,11 @@
 
         [:.witan-projection-table-row-selected
          :.witan-projection-table-row-selected:hover
-         {:background-color colour/row-selected}]])
+         {:background-color colour/row-selected}]
+
+        [:.witan-projection-table-row-descendant
+         {:color colour/darker-gray
+          :font-size (em 0.9)}
+         [:.name
+          {:margin-left (em 1)}]]])
       vec))

--- a/src/witan/styles/colours.clj
+++ b/src/witan/styles/colours.clj
@@ -6,6 +6,8 @@
 (def black (:black color/color-name->hex))
 (def gray (:gray color/color-name->hex))
 (def dark-gray (:darkgray color/color-name->hex))
+(def darker-gray (color/darken (:darkgray color/color-name->hex) 20))
+
 
 ;;
 (def button-success "#59cd90")

--- a/src/witan/styles/colours.clj
+++ b/src/witan/styles/colours.clj
@@ -8,7 +8,6 @@
 (def dark-gray (:darkgray color/color-name->hex))
 (def darker-gray (color/darken (:darkgray color/color-name->hex) 20))
 
-
 ;;
 (def button-success "#59cd90")
 (def button-error "#ee6352")

--- a/src/witan/styles/login.clj
+++ b/src/witan/styles/login.clj
@@ -9,94 +9,92 @@
 (defstyles login
   (-> (concat
         ;; fonts
-        f/font-face-definitions
+       f/font-face-definitions
 
         ;; style
-        [
-         ;; tags
-         [:*
-          {:box-sizing :border-box}]
-         [:html :body
-          {:width (percent 100)
-           :height (percent 100)
-           :margin (px 0)
-           :color colour/white
-           :font-family f/base-fonts}
-          [:input {:color colour/dark-gray}]]
+       [;; tags
+        [:*
+         {:box-sizing :border-box}]
+        [:html :body
+         {:width (percent 100)
+          :height (percent 100)
+          :margin (px 0)
+          :color colour/white
+          :font-family f/base-fonts}
+         [:input {:color colour/dark-gray}]]
 
-         [:a
-          {:text-decoration :none}]
-         [:a:hover
-          {:text-decoration :underline}]
+        [:a
+         {:text-decoration :none}]
+        [:a:hover
+         {:text-decoration :underline}]
 
          ;; classes
-         [:.bg
-          {:display :table
-           :position :relative
-           :width (percent 100)
-           :height (percent 100)
-           :background "transparent url(\"../img/login-bg.jpg\") no-repeat scroll center center / cover"}]
+        [:.bg
+         {:display :table
+          :position :relative
+          :width (percent 100)
+          :height (percent 100)
+          :background "transparent url(\"../img/login-bg.jpg\") no-repeat scroll center center / cover"}]
 
-         [:.bg-attribution
-          {:position :absolute
+        [:.bg-attribution
+         {:position :absolute
+          :background-color colour/login-black-bg
+          :color colour/gray
+          :font-size (em 0.65)
+          :font-family :monospace
+          :padding (em 0.2)
+          :margin (em 0.2)
+          :bottom (px 0)
+          :right (px 2)}]
+
+        [:.bg-attribution
+         [:a
+          {:text-decoration :none
+           :color colour/white}]]
+
+        [:#container
+         {:position :absolute
+          :top (percent 15)
+          :left (percent 5)}]
+
+        [:.title
+         {:postion :relative}
+         [:h1
+          {:font-size (em 5)
+           :font-weight 700
+           :padding "0px 0px 0px 20px"
+           :margin "10px 0px"
            :background-color colour/login-black-bg
-           :color colour/gray
-           :font-size (em 0.65)
-           :font-family :monospace
-           :padding (em 0.2)
-           :margin (em 0.2)
-           :bottom (px 0)
-           :right (px 2)}]
+           :background-clip :padding-box}]
+         [:h2
+          {:font-size (em 4)
+           :font-weight 400
+           :padding "0px 20px 10px 20px"
+           :margin (px 0)
+           :background-color colour/login-black-bg
+           :background-clip :padding-box}]]
 
-         [:.bg-attribution
-          [:a
-           {:text-decoration :none
-            :color colour/white}]]
-
-         [:#container
-          {:position :absolute
-           :top (percent 15)
-           :left (percent 5)}]
-
-         [:.title
-           {:postion :relative}
-          [:h1
-           {:font-size (em 5)
-            :font-weight 700
-            :padding "0px 0px 0px 20px"
-            :margin "10px 0px"
-            :background-color colour/login-black-bg
-            :background-clip :padding-box}]
-          [:h2
-           {:font-size (em 4)
-            :font-weight 400
-            :padding "0px 20px 10px 20px"
-            :margin (px 0)
-            :background-color colour/login-black-bg
-            :background-clip :padding-box}]]
-
-         [:#witan-login
-          {:margin-top (em 3)
-           :padding "1px 30px 20px 20px"
-           :height (percent 100)
-           :width (px 300)
-           :background-color colour/login-black-bg}
-          [:#loading
-           {:color colour/white
-            :margin "15px auto 0px auto"
-            :display :table}]
-          [:input
-           {:margin-bottom (em 0.5)
-            :width (percent 100)}]
-          [:#forgotten-link
-           {:font-size (px 10)
-            :vertical-align :text-top
-            :text-align :right
-            :float :right
-            :color colour/link
-            :cursor :pointer}]
-          [:.forgotten-div
-           [:#back-button
-            {:float :right}]]]
-         ])
+        [:#witan-login
+         {:margin-top (em 3)
+          :padding "1px 30px 20px 20px"
+          :height (percent 100)
+          :width (px 300)
+          :background-color colour/login-black-bg}
+         [:#loading
+          {:color colour/white
+           :margin "15px auto 0px auto"
+           :display :table}]
+         [:input
+          {:margin-bottom (em 0.5)
+           :width (percent 100)}]
+         [:#forgotten-link
+          {:font-size (px 10)
+           :vertical-align :text-top
+           :text-align :right
+           :float :right
+           :color colour/link
+           :cursor :pointer}]
+         [:.forgotten-div
+          [:#back-button
+           {:float :right}]]]])
       vec))

--- a/src/witan/ui/components/dashboard.cljs
+++ b/src/witan/ui/components/dashboard.cljs
@@ -29,7 +29,7 @@
                  [:button.pure-button.button-success
                   [:i.fa.fa-plus]]]]
                ;;
-               (if (not (empty? selected))
+               (if (not-empty selected)
                  [:li.witan-menu-item.pure-menu-item
                   [:a {:href (str "#/projection/" (second selected))}
                    [:button.pure-button.button-warning

--- a/src/witan/ui/components/dashboard.cljs
+++ b/src/witan/ui/components/dashboard.cljs
@@ -1,16 +1,16 @@
 (ns ^:figwheel-always witan.ui.components.dashboard
-    (:require [om.core :as om :include-macros true]
-              [om-tools.dom :as dom :include-macros true]
-              [om-tools.core :refer-macros [defcomponent]]
-              [sablono.core :as html :refer-macros [html]]
-              [inflections.core :as i]
-              [schema.core :as s :include-macros true]
+  (:require [om.core :as om :include-macros true]
+            [om-tools.dom :as dom :include-macros true]
+            [om-tools.core :refer-macros [defcomponent]]
+            [sablono.core :as html :refer-macros [html]]
+            [inflections.core :as i]
+            [schema.core :as s :include-macros true]
               ;;
-              [witan.ui.widgets :as widgets]
-              [witan.schema.core :refer [Projection]]
-              [witan.ui.util :refer [get-string]]
-              [witan.ui.async :refer [raise!]]
-              [witan.ui.refs :as refs]))
+            [witan.ui.widgets :as widgets]
+            [witan.schema.core :refer [Projection]]
+            [witan.ui.util :refer [get-string]]
+            [witan.ui.async :refer [raise!]]
+            [witan.ui.refs :as refs]))
 
 (defn get-selected-projection
   [cursor]

--- a/src/witan/ui/components/dashboard.cljs
+++ b/src/witan/ui/components/dashboard.cljs
@@ -26,7 +26,9 @@
              [:div.pure-menu.pure-menu-horizontal.witan-dash-heading
               [:h1
                (i/capitalize (get-string :projections))]
-              (om/build widgets/search-input (str (get-string :filter) " " (get-string :projections)))
+              (om/build widgets/search-input
+                        (str (get-string :filter) " " (get-string :projections))
+                        {:opts {:on-input #(raise! %1 :event/filter-projections %2)}})
               [:ul.pure-menu-list
                [:li.witan-menu-item.pure-menu-item
                 [:a {:href "#/new-projection"}

--- a/src/witan/ui/components/dashboard.cljs
+++ b/src/witan/ui/components/dashboard.cljs
@@ -16,7 +16,7 @@
   dash-header
   [cursor owner]
   (render [_]
-          (let [selected (om/observe owner (refs/selected-projection))]
+          (let [selected (:selected (om/observe owner (refs/projections-meta)))]
             (html
              [:div.pure-menu.pure-menu-horizontal.witan-dash-heading
               [:h1
@@ -31,17 +31,17 @@
                ;;
                (if (not (empty? selected))
                  [:li.witan-menu-item.pure-menu-item
-                  [:a {:href (str "#/projection/" (:id selected))}
+                  [:a {:href (str "#/projection/" (second selected))}
                    [:button.pure-button.button-warning
                     [:i.fa.fa-pencil]]]])
                (if (not (empty? selected))
                  [:li.witan-menu-item.pure-menu-item
-                  [:a {:href (str "#/projection/" (:id selected) "/download")}
+                  [:a {:href (str "#/projection/" (second selected) "/download")}
                    [:button.pure-button.button-primary
                     [:i.fa.fa-download]]]])
                (if (not (empty? selected))
                  [:li.witan-menu-item.pure-menu-item
-                  [:a {:href (str "#/share/" (:id selected))}
+                  [:a {:href (str "#/share/" (second selected))}
                    [:button.pure-button.button-primary
                     [:i.fa.fa-share-alt]]]])]]))))
 
@@ -64,4 +64,4 @@
               (om/build-all widgets/projection-tr
                             (:projections cursor)
                             {:key :id
-                             :opts {:on-click #(raise! %2 :event/select-projection %3)}})]]])))
+                             :opts {:on-click #(raise! %1 %2 %3)}})]]])))

--- a/src/witan/ui/components/dashboard.cljs
+++ b/src/witan/ui/components/dashboard.cljs
@@ -1,23 +1,27 @@
 (ns ^:figwheel-always witan.ui.components.dashboard
-  (:require [om.core :as om :include-macros true]
-            [om-tools.dom :as dom :include-macros true]
-            [om-tools.core :refer-macros [defcomponent]]
-            [sablono.core :as html :refer-macros [html]]
-            [inflections.core :as i]
-            [schema.core :as s :include-macros true]
+    (:require [om.core :as om :include-macros true]
+              [om-tools.dom :as dom :include-macros true]
+              [om-tools.core :refer-macros [defcomponent]]
+              [sablono.core :as html :refer-macros [html]]
+              [inflections.core :as i]
+              [schema.core :as s :include-macros true]
               ;;
-            [witan.ui.widgets :as widgets]
-            [witan.schema.core :refer [Projection]]
-            [witan.ui.util :refer [get-string]]
-            [witan.ui.async :refer [raise!]]
-            [witan.ui.refs :as refs]))
+              [witan.ui.widgets :as widgets]
+              [witan.schema.core :refer [Projection]]
+              [witan.ui.util :refer [get-string]]
+              [witan.ui.async :refer [raise!]]
+              [witan.ui.refs :as refs]))
+
+(defn get-selected-projection
+  [cursor]
+  (some #(if (= (:id %) (-> cursor :projections-meta :selected second)) %) (:projections cursor)))
 
 (defcomponent
   dash-header
-  [cursor owner]
+  [[selected top-level] owner]
   (render [_]
-          (let [selected (:selected (om/observe owner (refs/projections-meta)))
-                selected-id (second selected)]
+          (let [selected-id (:id selected)
+                is-top-level? (contains? top-level selected-id)]
             (html
              [:div.pure-menu.pure-menu-horizontal.witan-dash-heading
               [:h1
@@ -25,12 +29,10 @@
               (om/build widgets/search-input (str (get-string :filter) " " (get-string :projections)))
               [:ul.pure-menu-list
                [:li.witan-menu-item.pure-menu-item
-                ;; single button
                 [:a {:href "#/new-projection"}
                  [:button.pure-button.button-success
                   [:i.fa.fa-plus]]]]
-               ;;
-               (if (not-empty selected)
+               (if (and (not-empty selected) is-top-level?)
                  [:li.witan-menu-item.pure-menu-item
                   [:a {:href (str "#/projection/" selected-id)}
                    [:button.pure-button.button-warning
@@ -51,7 +53,12 @@
   (render [_]
           (html
            [:div
-            (om/build dash-header {})
+            (om/build dash-header [(get-selected-projection cursor)
+                                   (->> :projections
+                                        (-> cursor)
+                                        (filter (comp nil? :descendant-id))
+                                        (map :id)
+                                        set)])
             [:table.pure-table.pure-table-horizontal#witan-dash-projection-list
              [:thead
               [:th] ;; empty, for the tree icon

--- a/src/witan/ui/components/dashboard.cljs
+++ b/src/witan/ui/components/dashboard.cljs
@@ -16,7 +16,8 @@
   dash-header
   [cursor owner]
   (render [_]
-          (let [selected (:selected (om/observe owner (refs/projections-meta)))]
+          (let [selected (:selected (om/observe owner (refs/projections-meta)))
+                selected-id (second selected)]
             (html
              [:div.pure-menu.pure-menu-horizontal.witan-dash-heading
               [:h1
@@ -31,17 +32,17 @@
                ;;
                (if (not-empty selected)
                  [:li.witan-menu-item.pure-menu-item
-                  [:a {:href (str "#/projection/" (second selected))}
+                  [:a {:href (str "#/projection/" selected-id)}
                    [:button.pure-button.button-warning
                     [:i.fa.fa-pencil]]]])
                (if (not (empty? selected))
                  [:li.witan-menu-item.pure-menu-item
-                  [:a {:href (str "#/projection/" (second selected) "/download")}
+                  [:a {:href (str "#/projection/" selected-id "/download")}
                    [:button.pure-button.button-primary
                     [:i.fa.fa-download]]]])
                (if (not (empty? selected))
                  [:li.witan-menu-item.pure-menu-item
-                  [:a {:href (str "#/share/" (second selected))}
+                  [:a {:href (str "#/share/" selected-id)}
                    [:button.pure-button.button-primary
                     [:i.fa.fa-share-alt]]]])]]))))
 

--- a/src/witan/ui/components/dashboard.cljs
+++ b/src/witan/ui/components/dashboard.cljs
@@ -8,7 +8,7 @@
               ;;
             [witan.ui.widgets :as widgets]
             [witan.schema.core :refer [Projection]]
-            [witan.ui.util :refer [get-string]]
+            [witan.ui.data :refer [get-string]]
             [witan.ui.async :refer [raise!]]
             [witan.ui.refs :as refs]))
 

--- a/src/witan/ui/components/dashboard.cljs
+++ b/src/witan/ui/components/dashboard.cljs
@@ -1,16 +1,16 @@
 (ns ^:figwheel-always witan.ui.components.dashboard
-    (:require [om.core :as om :include-macros true]
-              [om-tools.dom :as dom :include-macros true]
-              [om-tools.core :refer-macros [defcomponent]]
-              [sablono.core :as html :refer-macros [html]]
-              [inflections.core :as i]
-              [schema.core :as s :include-macros true]
+  (:require [om.core :as om :include-macros true]
+            [om-tools.dom :as dom :include-macros true]
+            [om-tools.core :refer-macros [defcomponent]]
+            [sablono.core :as html :refer-macros [html]]
+            [inflections.core :as i]
+            [schema.core :as s :include-macros true]
               ;;
-              [witan.ui.widgets :as widgets]
-              [witan.schema.core :refer [Projection]]
-              [witan.ui.util :refer [get-string]]
-              [witan.ui.async :refer [raise!]]
-              [witan.ui.refs :as refs]))
+            [witan.ui.widgets :as widgets]
+            [witan.schema.core :refer [Projection]]
+            [witan.ui.util :refer [get-string]]
+            [witan.ui.async :refer [raise!]]
+            [witan.ui.refs :as refs]))
 
 (defcomponent
   dash-header

--- a/src/witan/ui/components/menu.cljs
+++ b/src/witan/ui/components/menu.cljs
@@ -1,14 +1,13 @@
 (ns ^:figwheel-always witan.ui.components.menu
-    (:require [om.core :as om :include-macros true]
-              [om-tools.dom :as dom :include-macros true]
-              [om-tools.core :refer-macros [defcomponent]]
-              [sablono.core :as html :refer-macros [html]]
-              [inflections.core :as i]
-              [schema.core :as s :include-macros true]
+  (:require [om.core :as om :include-macros true]
+            [om-tools.dom :as dom :include-macros true]
+            [om-tools.core :refer-macros [defcomponent]]
+            [sablono.core :as html :refer-macros [html]]
+            [inflections.core :as i]
+            [schema.core :as s :include-macros true]
               ;;
-              [witan.schema.core :refer [Projection]]
-              [witan.ui.util :refer [get-string]]))
-
+            [witan.schema.core :refer [Projection]]
+            [witan.ui.util :refer [get-string]]))
 
 (defcomponent
   view

--- a/src/witan/ui/components/menu.cljs
+++ b/src/witan/ui/components/menu.cljs
@@ -7,7 +7,7 @@
             [schema.core :as s :include-macros true]
               ;;
             [witan.schema.core :refer [Projection]]
-            [witan.ui.util :refer [get-string]]))
+            [witan.ui.data :refer [get-string]]))
 
 (defcomponent
   view

--- a/src/witan/ui/components/new_projection.cljs
+++ b/src/witan/ui/components/new_projection.cljs
@@ -8,7 +8,6 @@
               ;;
             [witan.ui.widgets :as widgets]
             [witan.schema.core :refer [Projection]]
-            [witan.ui.util :refer [get-string]]
             [witan.ui.async :refer [raise!]]
             [witan.ui.refs :as refs]))
 

--- a/src/witan/ui/components/new_projection.cljs
+++ b/src/witan/ui/components/new_projection.cljs
@@ -1,16 +1,16 @@
 (ns ^:figwheel-always witan.ui.components.new-projection
-    (:require [om.core :as om :include-macros true]
-              [om-tools.dom :as dom :include-macros true]
-              [om-tools.core :refer-macros [defcomponent]]
-              [sablono.core :as html :refer-macros [html]]
-              [inflections.core :as i]
-              [schema.core :as s :include-macros true]
+  (:require [om.core :as om :include-macros true]
+            [om-tools.dom :as dom :include-macros true]
+            [om-tools.core :refer-macros [defcomponent]]
+            [sablono.core :as html :refer-macros [html]]
+            [inflections.core :as i]
+            [schema.core :as s :include-macros true]
               ;;
-              [witan.ui.widgets :as widgets]
-              [witan.schema.core :refer [Projection]]
-              [witan.ui.util :refer [get-string]]
-              [witan.ui.async :refer [raise!]]
-              [witan.ui.refs :as refs]))
+            [witan.ui.widgets :as widgets]
+            [witan.schema.core :refer [Projection]]
+            [witan.ui.util :refer [get-string]]
+            [witan.ui.async :refer [raise!]]
+            [witan.ui.refs :as refs]))
 
 (defcomponent view
   [cursor owner args]

--- a/src/witan/ui/components/projection.cljs
+++ b/src/witan/ui/components/projection.cljs
@@ -8,7 +8,6 @@
               ;;
             [witan.ui.widgets :as widgets]
             [witan.schema.core :refer [Projection]]
-            [witan.ui.util :refer [get-string]]
             [witan.ui.async :refer [raise!]]
             [witan.ui.refs :as refs]))
 

--- a/src/witan/ui/components/projection.cljs
+++ b/src/witan/ui/components/projection.cljs
@@ -1,16 +1,16 @@
 (ns ^:figwheel-always witan.ui.components.projection
-    (:require [om.core :as om :include-macros true]
-              [om-tools.dom :as dom :include-macros true]
-              [om-tools.core :refer-macros [defcomponent]]
-              [sablono.core :as html :refer-macros [html]]
-              [inflections.core :as i]
-              [schema.core :as s :include-macros true]
+  (:require [om.core :as om :include-macros true]
+            [om-tools.dom :as dom :include-macros true]
+            [om-tools.core :refer-macros [defcomponent]]
+            [sablono.core :as html :refer-macros [html]]
+            [inflections.core :as i]
+            [schema.core :as s :include-macros true]
               ;;
-              [witan.ui.widgets :as widgets]
-              [witan.schema.core :refer [Projection]]
-              [witan.ui.util :refer [get-string]]
-              [witan.ui.async :refer [raise!]]
-              [witan.ui.refs :as refs]))
+            [witan.ui.widgets :as widgets]
+            [witan.schema.core :refer [Projection]]
+            [witan.ui.util :refer [get-string]]
+            [witan.ui.async :refer [raise!]]
+            [witan.ui.refs :as refs]))
 
 (defcomponent view
   [cursor owner {:keys [id] :as args}]

--- a/src/witan/ui/controllers/input.cljs
+++ b/src/witan/ui/controllers/input.cljs
@@ -1,7 +1,8 @@
 (ns ^:figwheel-always witan.ui.controllers.input
     (:require [om.core :as om :include-macros true]
               [schema.core :as s :include-macros true]
-              [witan.schema.core :refer [Projection]]))
+              [witan.schema.core :refer [Projection]]
+              [witan.ui.data :as d]))
 
 (defmulti handler
   (fn [[event args] cursor] event))
@@ -10,5 +11,17 @@
   :event/select-projection
   [[event args] cursor]
   (s/validate Projection args)
-  ;; we don't require backend for selection, so just update the cursor
-  (om/update! cursor :selected-projection args))
+  (om/update! cursor [:projections-meta :selected] (vector (:db/id args) (:id args))))
+
+(defmethod handler
+  :event/toggle-tree-view
+  [[event args] cursor]
+  (s/validate Projection args)
+  (let [db-id        (-> args :db/id)
+        id           (-> args :id)
+        is-toggled   (contains? (-> cursor :projections-meta :expanded) [db-id id])
+        fn           (if is-toggled disj conj)
+        new-state    (om/transact! cursor [:projections-meta :expanded] #(fn % [db-id id]))
+        all-expanded (-> @new-state :projections-meta :expanded)
+        toggled-on   (mapv #(vector :db/id (first %)) all-expanded)]
+    (om/update! cursor :projections (d/fetch-projections {:expand toggled-on}))))

--- a/src/witan/ui/controllers/input.cljs
+++ b/src/witan/ui/controllers/input.cljs
@@ -1,8 +1,8 @@
 (ns ^:figwheel-always witan.ui.controllers.input
-    (:require [om.core :as om :include-macros true]
-              [schema.core :as s :include-macros true]
-              [witan.schema.core :refer [Projection]]
-              [witan.ui.data :as d]))
+  (:require [om.core :as om :include-macros true]
+            [schema.core :as s :include-macros true]
+            [witan.schema.core :refer [Projection]]
+            [witan.ui.data :as d]))
 
 (defmulti handler
   (fn [[event args] cursor] event))

--- a/src/witan/ui/controllers/input.cljs
+++ b/src/witan/ui/controllers/input.cljs
@@ -7,8 +7,10 @@
 (defn fetch-visible-projections
   [state]
   (let [all-expanded (-> state :projections-meta :expanded)
+        filter (-> state :projections-meta :filter)
         toggled-on (mapv #(vector :db/id (first %)) all-expanded)]
-    (d/fetch-projections {:expand toggled-on})))
+    (d/fetch-projections {:expand toggled-on
+                          :filter filter})))
 
 (defmulti handler
   (fn [[event args] cursor] event))

--- a/src/witan/ui/core.cljs
+++ b/src/witan/ui/core.cljs
@@ -1,26 +1,26 @@
 (ns ^:figwheel-always witan.ui.core
-    (:require [cljs.core.async :as async :refer [>! <! alts! chan close!]]
-              [om.core :as om :include-macros true]
-              [goog.events :as events]
-              [goog.history.EventType :as EventType]
-              [om-tools.dom :as dom :include-macros true]
-              [om-tools.core :refer-macros [defcomponent]]
-              [sablono.core :as html :refer-macros [html]]
-              [inflections.core :as i]
-              [schema.core :as s :include-macros true]
-              [secretary.core :as secretary :refer-macros [defroute]]
+  (:require [cljs.core.async :as async :refer [>! <! alts! chan close!]]
+            [om.core :as om :include-macros true]
+            [goog.events :as events]
+            [goog.history.EventType :as EventType]
+            [om-tools.dom :as dom :include-macros true]
+            [om-tools.core :refer-macros [defcomponent]]
+            [sablono.core :as html :refer-macros [html]]
+            [inflections.core :as i]
+            [schema.core :as s :include-macros true]
+            [secretary.core :as secretary :refer-macros [defroute]]
               ;;
-              [witan.schema.core :refer [Projection]]
-              [witan.ui.util :refer [prependtial]]
-              [witan.ui.components.dashboard]
-              [witan.ui.components.menu]
-              [witan.ui.components.new-projection]
-              [witan.ui.components.projection]
-              [witan.ui.controllers.input]
-              [witan.ui.data :as data])
-    (:require-macros [cljs.core.async.macros :as am :refer [go go-loop alt!]])
+            [witan.schema.core :refer [Projection]]
+            [witan.ui.util :refer [prependtial]]
+            [witan.ui.components.dashboard]
+            [witan.ui.components.menu]
+            [witan.ui.components.new-projection]
+            [witan.ui.components.projection]
+            [witan.ui.controllers.input]
+            [witan.ui.data :as data])
+  (:require-macros [cljs.core.async.macros :as am :refer [go go-loop alt!]])
 
-    (:import goog.History))
+  (:import goog.History))
 
 (enable-console-print!)
 
@@ -43,15 +43,15 @@
 
 ;; this is the primary routing table
 (defonce navigation-state
-  (atom { :routes [{:name "Dashboard"
-           :path "/"
-           :view (fn [] witan.ui.components.dashboard/view)}
-          {:name "New Projection"
-           :path "/new-projection"
-           :view (fn [] witan.ui.components.new-projection/view)}
-          {:name "Projection Wizard"
-           :path "/projection/:id"
-           :view (fn [] witan.ui.components.projection/view)}]
+  (atom {:routes [{:name "Dashboard"
+                   :path "/"
+                   :view (fn [] witan.ui.components.dashboard/view)}
+                  {:name "New Projection"
+                   :path "/new-projection"
+                   :view (fn [] witan.ui.components.new-projection/view)}
+                  {:name "Projection Wizard"
+                   :path "/projection/:id"
+                   :view (fn [] witan.ui.components.projection/view)}]
          :current-route ""}))
 
 (defonce define-app-state

--- a/src/witan/ui/core.cljs
+++ b/src/witan/ui/core.cljs
@@ -56,38 +56,12 @@
 
 (defonce define-app-state
   (do
-    (data/set-app-state! {:strings strings
-                          :projections [{:id "1234"
-                                         :name "Population Projection for Camden"
-                                         :type :population
-                                         :owner "Camden"
-                                         :version 3
-                                         :last-modified "Aug 10th, 2015"
-                                         :last-modifier "Neil"
-                                         :previous-version {:id "1233"
-                                                            :name "Population Projection for Camden"
-                                                            :type :population
-                                                            :owner "Camden"
-                                                            :version 2
-                                                            :last-modified "Aug 8th, 2015"
-                                                            :last-modifier "Simon"
-                                                            :previous-version {:id "1232"
-                                                                               :name "Population Projection for Camden"
-                                                                               :type :population
-                                                                               :owner "Camden"
-                                                                               :version 1
-                                                                               :last-modified "Aug 6th, 2015"
-                                                                               :last-modifier "Frank"
-                                                                               :previous-version nil}}}
-                                        {:id "5678"
-                                         :name "Population Projection for Bexley"
-                                         :type :population
-                                         :owner "Bexley"
-                                         :version 2
-                                         :last-modified "July 22nd, 2015"
-                                         :last-modifier "Sarah"
-                                         :previous-version nil}]
-                          :selected-projection {}})))
+    (reset! data/app-state {:strings strings
+                            :projections []
+                            :projections-meta {:expanded #{}
+                                               :selected []
+                                               :has-ancestors #{}}})
+    (data/load-dummy-data!)))
 
 ;; VALIDATE - make sure our app-state matches the schema
 ;; FIXME we should only do this in dev/testing (possibly staging?)
@@ -120,20 +94,6 @@
 ;; this automatically patches up the routing table that is defined above
 (doseq [{:keys [path view]} (:routes @navigation-state)]
   (defroute (str path)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     {:as params}
     (install-om! view params)))
 

--- a/src/witan/ui/core.cljs
+++ b/src/witan/ui/core.cljs
@@ -60,7 +60,8 @@
                             :projections []
                             :projections-meta {:expanded #{}
                                                :selected []
-                                               :has-ancestors #{}}})
+                                               :has-ancestors #{}
+                                               :filter ""}})
     (data/load-dummy-data!)))
 
 ;; VALIDATE - make sure our app-state matches the schema

--- a/src/witan/ui/data.cljs
+++ b/src/witan/ui/data.cljs
@@ -21,7 +21,7 @@
          remaining-nodes []]
     (let [new-results (conj results (:db/id node))
           new-remaining (concat remaining-nodes (fetch-ancestor-projection (:id node)))]
-      (if (not (empty? new-remaining))
+      (if (not-empty new-remaining)
         (recur (d/touch (d/entity @db-conn (:db/id (first new-remaining)))) new-results (rest new-remaining))
         new-results))))
 
@@ -36,7 +36,7 @@
       top-level
       (if (vector? expand)
         (mapcat (fn [projection]
-                  (if (first (filter (fn [[ck cv]] (= (ck projection) cv)) expand))
+                  (if (some (fn [[ck cv]] (if (= (ck projection) cv) [ck cv])) expand)
                     (let [db-id (:db/id projection)
                           desc-tree (rest (build-descendant-list db-id))]
                       (apply conj [projection] (mapv #(merge {} (d/pull @db-conn '[*] %)) desc-tree)))

--- a/src/witan/ui/data.cljs
+++ b/src/witan/ui/data.cljs
@@ -1,9 +1,103 @@
-(ns ^:figwheel-always witan.ui.data)
+(ns ^:figwheel-always witan.ui.data
+    (:require [datascript :as d]))
 
 (defonce app-state (atom {}))
+(defonce db-schema {})
+(defonce db-conn (d/create-conn db-schema))
 
-(defn set-app-state!
-  [m]
-  (if (map? m)
-    (reset! app-state m)
-    (throw (js/Error. "App state must be a map"))))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn fetch-ancestor-projection
+  "TODO This currently only handles the FIRST child. No support for branching."
+  [id]
+  (first (d/q '[:find (pull ?e [*])
+                :in $ ?i
+                :where [?e :descendant-id ?i]] @db-conn id)))
+
+(defn build-descendant-list
+  [db-id]
+  (loop [node (d/touch (d/entity @db-conn db-id))
+         results []
+         remaining-nodes []]
+    (let [new-results (conj results (:db/id node))
+          new-remaining (concat remaining-nodes (fetch-ancestor-projection (:id node)))]
+      (if (not (empty? new-remaining))
+        (recur (d/touch (d/entity @db-conn (:db/id (first new-remaining)))) new-results (rest new-remaining))
+        new-results))))
+
+(defn fetch-projections
+  [{:keys [expand] :or {expand false}}]
+  (let [top-level (apply concat (d/q '[:find (pull ?e [*])
+                                       :where [?e :id _]
+                                       [(get-else $ ?e :descendant-id nil) ?u]
+                                       [(nil? ?u)]]
+                                     @db-conn))]
+    (if-not expand
+      top-level
+      (if (vector? expand)
+        (mapcat (fn [projection]
+                  (if (first (filter (fn [[ck cv]] (= (ck projection) cv)) expand))
+                    (let [db-id (:db/id projection)
+                          desc-tree (rest (build-descendant-list db-id))]
+                      (apply conj [projection] (mapv #(merge {} (d/pull @db-conn '[*] %)) desc-tree)))
+                    [projection])) top-level)
+        (throw (js/Error. ":expand must be a vector of [k v] vectors"))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn load-dummy-data!
+  []
+  (println "Loading dummy data...")
+  (let [projections [{:id "1234"
+                      :name "Population Projection for Camden"
+                      :type :population
+                      :owner "Camden"
+                      :version 3
+                      :last-modified "Aug 10th, 2015"
+                      :last-modifier "Neil"}
+                     {:id "1233"
+                      :name "Population Projection for Camden"
+                      :type :population
+                      :owner "Camden"
+                      :version 2
+                      :last-modified "Aug 8th, 2015"
+                      :last-modifier "Simon"
+                      :descendant-id "1234"}
+                     {:id "1232"
+                      :name "Population Projection for Camden"
+                      :type :population
+                      :owner "Camden"
+                      :version 1
+                      :last-modified "July 4th, 2015"
+                      :last-modifier "GLA"
+                      :descendant-id "1233"}
+                     {:id "5678"
+                      :name "Population Projection for Bexley"
+                      :type :population
+                      :owner "Bexley"
+                      :version 2
+                      :last-modified "July 22nd, 2015"
+                      :last-modifier "Sarah"}
+                     {:id "5676"
+                      :name "Population Projection for Bexley"
+                      :type :population
+                      :owner "Bexley"
+                      :version 1
+                      :last-modified "June 14th, 2015"
+                      :last-modifier "Sarah"
+                      :descendant-id "5678"}
+                     {:id "3339"
+                      :name "Population Projection for Hackney"
+                      :type :population
+                      :owner "Hackney"
+                      :version 1
+                      :last-modified "Feb 14th, 2015"
+                      :last-modifier "Deepak"}]
+        _ (d/transact! db-conn projections)
+        db-projections (fetch-projections {})
+        has-ancs (->>
+                  (filter #(and (-> % :id fetch-ancestor-projection empty? not) (nil? (:descendant-id %))) db-projections)
+                  (map #(vector (:db/id %) (:id %)))
+                  set)]
+    (swap! app-state assoc :projections db-projections)
+    (swap! app-state assoc-in [:projections-meta :has-ancestors] has-ancs)))

--- a/src/witan/ui/data.cljs
+++ b/src/witan/ui/data.cljs
@@ -1,5 +1,5 @@
 (ns ^:figwheel-always witan.ui.data
-    (:require [datascript :as d]))
+  (:require [datascript :as d]))
 
 (defonce app-state (atom {}))
 (defonce db-schema {})

--- a/src/witan/ui/refs.cljs
+++ b/src/witan/ui/refs.cljs
@@ -2,6 +2,9 @@
     (:require [om.core :as om :include-macros true]
               [witan.ui.data :refer [app-state]]))
 
-(defn selected-projection
+(defn projections-meta
   []
-  (om/ref-cursor (:selected-projection (om/root-cursor app-state))))
+  (-> app-state
+      om/root-cursor
+      :projections-meta
+      om/ref-cursor))

--- a/src/witan/ui/refs.cljs
+++ b/src/witan/ui/refs.cljs
@@ -1,6 +1,6 @@
 (ns ^:figwheel-always witan.ui.refs
-    (:require [om.core :as om :include-macros true]
-              [witan.ui.data :refer [app-state]]))
+  (:require [om.core :as om :include-macros true]
+            [witan.ui.data :refer [app-state]]))
 
 (defn projections-meta
   []

--- a/src/witan/ui/util.cljs
+++ b/src/witan/ui/util.cljs
@@ -1,10 +1,4 @@
-(ns ^:figwheel-always witan.ui.util
-  (:require [witan.ui.data :refer [app-state]]))
-
-(defn get-string
-  "Assumes that strings are always in the :strings keyword"
-  [keyword]
-  (-> @app-state :strings keyword))
+(ns ^:figwheel-always witan.ui.util)
 
 (defn prependtial
   "Works like `partial` except the additional args are prepended, rather than appended.

--- a/src/witan/ui/util.cljs
+++ b/src/witan/ui/util.cljs
@@ -15,5 +15,11 @@
     (apply f (concat args2 args1))))
 
 (defn contains-str
+  "Performs a case-insensitive substring match"
   [source match]
-  (not= -1 (.indexOf source match)))
+  (not= -1 (.indexOf (.toLowerCase source) (.toLowerCase match))))
+
+(defn contains-str-regex
+  "Performs a case-insensitive regex match"
+  [source pattern]
+  (boolean (re-find (js/RegExp. pattern "i") source)))

--- a/src/witan/ui/util.cljs
+++ b/src/witan/ui/util.cljs
@@ -1,5 +1,5 @@
 (ns ^:figwheel-always witan.ui.util
-    (:require [witan.ui.data :refer [app-state]]))
+  (:require [witan.ui.data :refer [app-state]]))
 
 (defn get-string
   "Assumes that strings are always in the :strings keyword"

--- a/src/witan/ui/util.cljs
+++ b/src/witan/ui/util.cljs
@@ -13,3 +13,7 @@
   [f & args1]
   (fn [& args2]
     (apply f (concat args2 args1))))
+
+(defn contains-str
+  [source match]
+  (not= -1 (.indexOf source match)))

--- a/src/witan/ui/widgets.cljs
+++ b/src/witan/ui/widgets.cljs
@@ -54,7 +54,8 @@
               [:td.tree-control (cond
                                   is-expanded? [:i.fa.fa-minus-square-o.tree-control]
                                   has-ancestor? [:i.fa.fa-plus-square-o.tree-control])]
-              [:td (:name projection)]
+              [:td
+               [:span.name (:name projection)]]
               [:td.text-center (-> projection :type name i/capitalize)]
               [:td.text-center (:owner projection)]
               [:td.text-center (:version projection)]

--- a/src/witan/ui/widgets.cljs
+++ b/src/witan/ui/widgets.cljs
@@ -13,17 +13,17 @@
   [placeholder owner & opts]
   (render [_]
           (let [{:keys [on-input]} (first opts)]
-          (html
-           [:form.pure-form
-            [:div.witan-search-input
-             [:i.fa.fa-search]
-             [:input {:id "filter-input"
-                      :type "text"
-                      :placeholder placeholder
-                      :on-input (fn [e]
-                                  (if (fn? on-input)
-                                    (on-input owner (.. e -target -value)))
-                                  (.preventDefault e))}]]]))))
+            (html
+             [:form.pure-form
+              [:div.witan-search-input
+               [:i.fa.fa-search]
+               [:input {:id "filter-input"
+                        :type "text"
+                        :placeholder placeholder
+                        :on-input (fn [e]
+                                    (if (fn? on-input)
+                                      (on-input owner (.. e -target -value)))
+                                    (.preventDefault e))}]]]))))
 
 (defcomponent
   projection-tr

--- a/src/witan/ui/widgets.cljs
+++ b/src/witan/ui/widgets.cljs
@@ -4,7 +4,8 @@
              [om-tools.core :refer-macros [defcomponent]]
              [sablono.core :as html :refer-macros [html]]
              [inflections.core :as i]
-             [witan.ui.refs :as refs]))
+             [witan.ui.refs :as refs]
+             [witan.ui.util :refer [contains-str]]))
 
 ;; search input
 (defcomponent
@@ -23,20 +24,38 @@
   projection-tr
   [projection owner & opts]
   (render [_]
-          (let [{:keys [on-click selected-projection-id]} (first opts)
-                is-selected-projection? (= (:id projection)
-                                           (-> owner
-                                               (om/observe (refs/selected-projection))
-                                               :id))]
+          (let [{:keys [on-click]} (first opts)
+                projections-meta        (om/observe owner (refs/projections-meta))
+                selected-projection     (:selected projections-meta)
+                ancestor-set            (set (map second (:has-ancestors projections-meta)))
+                expanded-set            (set (map second (:expanded projections-meta)))
+                is-selected-projection? (= (:id projection) (second selected-projection))
+                has-ancestor?           (contains? ancestor-set (:id projection))
+                is-expanded?            (contains? expanded-set (:id projection))
+                has-descendant?         (not (nil? (:descendant-id projection)))
+                classes                 [[is-selected-projection? "witan-projection-table-row-selected"]
+                                         [has-descendant? "witan-projection-table-row-descendant"]]]
             (html
              [:tr.witan-projection-table-row {:key (:id projection)
-                                              :class (if is-selected-projection? "witan-projection-table-row-selected" "")
+                                              :class (->> classes
+                                                          (filter first)
+                                                          (map second)
+                                                          (interpose " ")
+                                                          (apply str))
                                               :on-click (fn [e]
-                                                          (if (fn? on-click) (on-click e owner @projection))
+                                                          (if (fn? on-click)
+                                                            (if (and
+                                                                 has-ancestor?
+                                                                 (contains-str (.. e -target -className) "tree-control"))
+                                                              (on-click owner :event/toggle-tree-view projection e)
+                                                              (on-click owner :event/select-projection projection e)))
                                                           (.preventDefault e))}
-              [:td.tree-control [:i.fa.fa-plus-square-o]]
+
+              [:td.tree-control (cond
+                                  is-expanded? [:i.fa.fa-minus-square-o.tree-control]
+                                  has-ancestor? [:i.fa.fa-plus-square-o.tree-control])]
               [:td (:name projection)]
-              [:td.text-center (name (i/capitalize (:type projection)))]
+              [:td.text-center (-> projection :type name i/capitalize)]
               [:td.text-center (:owner projection)]
               [:td.text-center (:version projection)]
               [:td.text-center

--- a/src/witan/ui/widgets.cljs
+++ b/src/witan/ui/widgets.cljs
@@ -1,11 +1,11 @@
 (ns ^:figwheel-always witan.ui.widgets
-    (:require[om.core :as om :include-macros true]
-             [om-tools.dom :as dom :include-macros true]
-             [om-tools.core :refer-macros [defcomponent]]
-             [sablono.core :as html :refer-macros [html]]
-             [inflections.core :as i]
-             [witan.ui.refs :as refs]
-             [witan.ui.util :refer [contains-str]]))
+  (:require [om.core :as om :include-macros true]
+            [om-tools.dom :as dom :include-macros true]
+            [om-tools.core :refer-macros [defcomponent]]
+            [sablono.core :as html :refer-macros [html]]
+            [inflections.core :as i]
+            [witan.ui.refs :as refs]
+            [witan.ui.util :refer [contains-str]]))
 
 ;; search input
 (defcomponent

--- a/src/witan/ui/widgets.cljs
+++ b/src/witan/ui/widgets.cljs
@@ -10,15 +10,20 @@
 ;; search input
 (defcomponent
   search-input
-  [placeholder owner]
+  [placeholder owner & opts]
   (render [_]
+          (let [{:keys [on-input]} (first opts)]
           (html
            [:form.pure-form
             [:div.witan-search-input
              [:i.fa.fa-search]
              [:input {:id "filter-input"
                       :type "text"
-                      :placeholder placeholder}]]])))
+                      :placeholder placeholder
+                      :on-input (fn [e]
+                                  (if (fn? on-input)
+                                    (on-input owner (.. e -target -value)))
+                                  (.preventDefault e))}]]]))))
 
 (defcomponent
   projection-tr


### PR DESCRIPTION
**_But, why?**_

I think keeping a single 'app state with everything in it' is a naive approach to handling React applications. At any one time my prediction is that we'll have more data than we need to physically display (prime example being all a user's available projections). Datascript sits as a cache between 'data fetched from the server' and 'what the frontend is currently interested in' and obviously makes things more manageable at the app state level without the latency trade-off of having to hit the server every time we need to fetch data that we've had to jettison.
