### PR TITLE
Add named routes

### DIFF
--- a/src/witan/ui/components/dashboard.cljs
+++ b/src/witan/ui/components/dashboard.cljs
@@ -12,8 +12,7 @@
             [witan.ui.async :refer [raise!]]
             [witan.ui.refs :as refs]
             [witan.ui.util :refer [goto-window-location!]]
-            [witan.ui.nav :as nav]
-            ))
+            [witan.ui.nav :as nav]))
 
 (defn get-selected-projection
   [cursor]

--- a/src/witan/ui/components/dashboard.cljs
+++ b/src/witan/ui/components/dashboard.cljs
@@ -11,7 +11,9 @@
             [witan.ui.data :refer [get-string]]
             [witan.ui.async :refer [raise!]]
             [witan.ui.refs :as refs]
-            [witan.ui.util :refer [goto-window-location!]]))
+            [witan.ui.util :refer [goto-window-location!]]
+            [witan.ui.nav :as nav]
+            ))
 
 (defn get-selected-projection
   [cursor]
@@ -32,17 +34,17 @@
                         {:opts {:on-input #(raise! %1 :event/filter-projections %2)}})
               [:ul.pure-menu-list
                [:li.witan-menu-item.pure-menu-item
-                [:a {:href "#/new-projection"}
+                [:a {:href (nav/new-projection)}
                  [:button.pure-button.button-success
                   [:i.fa.fa-plus]]]]
                (if (and (not-empty selected) is-top-level?)
                  [:li.witan-menu-item.pure-menu-item
-                  [:a {:href (str "#/projection/" selected-id)}
+                  [:a {:href (nav/projection-wizard {:id selected-id :action ""})}
                    [:button.pure-button.button-warning
                     [:i.fa.fa-pencil]]]])
                (if (not (empty? selected))
                  [:li.witan-menu-item.pure-menu-item
-                  [:a {:href (str "#/projection/" selected-id "/download")}
+                  [:a {:href (nav/projection-wizard {:id selected-id :action "download"})}
                    [:button.pure-button.button-primary
                     [:i.fa.fa-download]]]])
                (if (not (empty? selected))
@@ -77,4 +79,5 @@
                             {:key :id
                              :opts {:on-click #(raise! %1 %2 %3)
                                     :on-double-click #(if (nil? (:descendant-id %2))
-                                                        (goto-window-location! (str "#/projection/" (:id %2))))}})]]])))
+                                                        (goto-window-location!
+                                                         (nav/projection-wizard {:id (:id %2) :action ""})))}})]]])))

--- a/src/witan/ui/controllers/input.cljs
+++ b/src/witan/ui/controllers/input.cljs
@@ -36,5 +36,6 @@
   :event/filter-projections
   [[event args] cursor]
   (s/validate s/Str args)
-  (let [new-state (om/update! cursor [:projections-meta :filter] args)]
+  (let [new-filter (if (empty? args) nil args)
+        new-state (om/update! cursor [:projections-meta :filter] new-filter)]
     (om/update! cursor :projections (fetch-visible-projections @new-state))))

--- a/src/witan/ui/controllers/input.cljs
+++ b/src/witan/ui/controllers/input.cljs
@@ -36,6 +36,6 @@
   :event/filter-projections
   [[event args] cursor]
   (s/validate s/Str args)
-  (let [new-filter (if (empty? args) nil args)
+  (let [new-filter (not-empty args)
         new-state (om/update! cursor [:projections-meta :filter] new-filter)]
     (om/update! cursor :projections (fetch-visible-projections @new-state))))

--- a/src/witan/ui/core.cljs
+++ b/src/witan/ui/core.cljs
@@ -55,12 +55,12 @@
 (defonce define-app-state
   (do
     (reset! data/app-state {:strings strings
-                            :current-route ""
+                            :current-route nil
                             :projections []
                             :projections-meta {:expanded #{}
                                                :selected []
                                                :has-ancestors #{}
-                                               :filter ""}})
+                                               :filter nil}})
     (data/load-dummy-data!)))
 
 ;; VALIDATE - make sure our app-state matches the schema

--- a/src/witan/ui/core.cljs
+++ b/src/witan/ui/core.cljs
@@ -9,15 +9,16 @@
             [inflections.core :as i]
             [schema.core :as s :include-macros true]
             [secretary.core :as secretary :refer-macros [defroute]]
-              ;;
+            ;;
             [witan.schema.core :refer [Projection]]
             [witan.ui.util :refer [prependtial]]
+            [witan.ui.controllers.input]
+            [witan.ui.data :as data]
+            [witan.ui.nav :as nav]
+            [witan.ui.components.projection]
             [witan.ui.components.dashboard]
             [witan.ui.components.menu]
-            [witan.ui.components.new-projection]
-            [witan.ui.components.projection]
-            [witan.ui.controllers.input]
-            [witan.ui.data :as data])
+            [witan.ui.components.new-projection])
   (:require-macros [cljs.core.async.macros :as am :refer [go go-loop alt!]])
 
   (:import goog.History))
@@ -28,8 +29,18 @@
 ;; DEFS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def comms
-  {:input (chan)})
+(defonce define-comms-channels
+  (do
+    (reset! nav/comms
+            {:input (chan)})))
+
+(defonce define-views
+  (do
+    (reset! nav/views
+            {:projection     witan.ui.components.projection/view
+             :dashboard      witan.ui.components.dashboard/view
+             :new-projection witan.ui.components.new-projection/view
+             :menu           witan.ui.components.menu/view})))
 
 (defonce strings
   {:witan-title             "Witan for London"
@@ -41,22 +52,10 @@
    :projection-version      "Version"
    :projection-lastmodified "Last Modified"})
 
-;; this is the primary routing table
-(defonce navigation-state
-  (atom {:routes [{:name "Dashboard"
-                   :path "/"
-                   :view (fn [] witan.ui.components.dashboard/view)}
-                  {:name "New Projection"
-                   :path "/new-projection"
-                   :view (fn [] witan.ui.components.new-projection/view)}
-                  {:name "Projection Wizard"
-                   :path "/projection/:id"
-                   :view (fn [] witan.ui.components.projection/view)}]
-         :current-route ""}))
-
 (defonce define-app-state
   (do
     (reset! data/app-state {:strings strings
+                            :current-route ""
                             :projections []
                             :projections-meta {:expanded #{}
                                                :selected []
@@ -69,38 +68,15 @@
 (doseq [p (:projections @data/app-state)]
   (s/validate Projection p))
 
-(def history (History.))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; ROUTING FUNCTIONS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn find-app-container
-  []
-  (. js/document (getElementById "witan-main")))
-
-(defn install-om!
-  [view params]
-  (om/root
-   (prependtial (view) params)
-   data/app-state
-   {:target (find-app-container)
-    :shared {:comms comms}})
-
-  (om/root
-   witan.ui.components.menu/view
-   data/app-state
-   {:target (. js/document (getElementById "witan-menu"))}))
-
-;; this automatically patches up the routing table that is defined above
-(doseq [{:keys [path view]} (:routes @navigation-state)]
-  (defroute (str path)
-    {:as params}
-    (install-om! view params)))
+(def history (History.))
 
 (defn on-navigate [event]
   (let [path (.-token event)]
-    (swap! navigation-state assoc :current-route path)
+    (swap! data/app-state assoc :current-route path)
     (secretary/dispatch! path)))
 
 (defonce set-up-history!
@@ -110,8 +86,8 @@
 
 (defn on-js-reload []
   ;; this is required for the figwheel reload
-  (om/detach-root (find-app-container))
-  (secretary/dispatch! (:current-route @navigation-state)))
+  (om/detach-root (nav/find-app-container))
+  (secretary/dispatch! (:current-route @data/app-state)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; MESSAGE HANDLING
@@ -120,7 +96,7 @@
 (go
   (while true
     (alt!
-      (:input comms) ([v] (witan.ui.controllers.input/handler v (om/root-cursor data/app-state)))
+      (:input @nav/comms) ([v] (witan.ui.controllers.input/handler v (om/root-cursor data/app-state)))
       ;; Capture the current history for playback in the absence
       ;; of a server to store it
       (async/timeout 10000) (do #_(print "TODO: print out history: ")))))

--- a/src/witan/ui/data.cljs
+++ b/src/witan/ui/data.cljs
@@ -1,6 +1,6 @@
 (ns ^:figwheel-always witan.ui.data
-    (:require [datascript :as d]
-              [witan.ui.util :as util]))
+  (:require [datascript :as d]
+            [witan.ui.util :as util]))
 
 (defonce app-state (atom {}))
 (defonce db-schema {})
@@ -35,8 +35,8 @@
   [{:keys [expand filter] :or {expand false
                                filter nil}}] ;; filter is only applied to top-level projections.
   (let [pred (fn [n] (if (nil? filter)
-                         true
-                         (util/contains-str n filter)))
+                       true
+                       (util/contains-str n filter)))
         top-level (apply concat (d/q '[:find (pull ?e [*])
                                        :in $ ?pred
                                        :where [?e :id _]

--- a/src/witan/ui/nav.cljs
+++ b/src/witan/ui/nav.cljs
@@ -1,10 +1,9 @@
 (ns ^:figwheel-always witan.ui.nav
-    (:require [cljs.core.async :as async :refer [>! <! alts! chan close!]]
-              [secretary.core :as secretary :refer-macros [defroute]]
-              [om.core :as om :include-macros true]
-              [witan.ui.data :as data]
-              [witan.ui.util :refer [prependtial]]
-              ))
+  (:require [cljs.core.async :as async :refer [>! <! alts! chan close!]]
+            [secretary.core :as secretary :refer-macros [defroute]]
+            [om.core :as om :include-macros true]
+            [witan.ui.data :as data]
+            [witan.ui.util :refer [prependtial]]))
 
 (defonce comms (atom {}))
 (defonce views (atom {:projection nil

--- a/src/witan/ui/nav.cljs
+++ b/src/witan/ui/nav.cljs
@@ -1,0 +1,50 @@
+(ns ^:figwheel-always witan.ui.nav
+    (:require [cljs.core.async :as async :refer [>! <! alts! chan close!]]
+              [secretary.core :as secretary :refer-macros [defroute]]
+              [om.core :as om :include-macros true]
+              [witan.ui.data :as data]
+              [witan.ui.util :refer [prependtial]]
+              ))
+
+(defonce comms (atom {}))
+(defonce views (atom {:projection nil
+                      :dashboard nil
+                      :new-projection nil
+                      :menu nil}))
+
+(defn find-app-container
+  []
+  (. js/document (getElementById "witan-main")))
+
+(defn install-om!
+  [view params]
+  ;; main view
+  (om/root
+   (prependtial (view) params)
+   data/app-state
+   {:target (find-app-container)
+    :shared {:comms @comms}})
+  ;; menu
+  (om/root
+   ((fn [] (:menu @views)))
+   data/app-state
+   {:target (. js/document (getElementById "witan-menu"))}))
+
+;;;;;;;;;;;;;
+
+(secretary/set-config! :prefix "#")
+
+(defroute dashboard
+  "/"
+  {:as params}
+  (install-om! (fn [] (:dashboard @views)) params))
+
+(defroute projection-wizard
+  "/projection/:id/*action"
+  {:as params}
+  (install-om! (fn [] (:projection @views)) params))
+
+(defroute new-projection
+  "/new-projection/"
+  {:as params}
+  (install-om! (fn [] (:new-projection @views)) params))


### PR DESCRIPTION
This replaces the "magic" auto-routing for plain old `defroutes`, which enables us to use secretary's named routes for navigation at other points in the app, instead of hard-coded, unsafe methods like...

```
(str "#/projection/" id "/" action)
```

...which is horrid.
