### PR TITLE
Integrate model diagram into forecast page.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,9 @@
                  [inflections "0.9.14"]
                  [prismatic/schema "0.4.3"]
                  [secretary "1.2.3"]
-                 [datascript "0.11.6"]]
+                 [datascript "0.11.6"]
+                 [thi.ng/geom "0.0.881"]
+                 [hiccups "0.3.0"]]
 
   :plugins [[lein-cljsbuild "1.0.5"]
             [lein-figwheel "0.3.5"]

--- a/src/witan/schema/core.cljc
+++ b/src/witan/schema/core.cljc
@@ -24,6 +24,8 @@
   {(s/required-key :id)            ForecastIdType
    (s/required-key :name)          s/Str
    (s/required-key :type)          ForecastTypes
+   (s/required-key :n-inputs)      s/Int
+   (s/required-key :n-outputs)     [s/Int]
    (s/required-key :owner)         s/Str
    (s/required-key :version)       s/Int
    (s/required-key :last-modified) s/Str

--- a/src/witan/styles/base.clj
+++ b/src/witan/styles/base.clj
@@ -156,6 +156,16 @@
          [:.name
           {:margin-left (em 1)}]]
 
+        [:.witan-model-diagram
+         {:stroke colour/black
+          :stroke-width 3
+          :text-align "center"}
+         [:.input {:fill colour/forecast-input}]
+         [:.output {:fill colour/forecast-output}]
+         [:.model {:fill colour/forecast-model}]
+         [:.group {:fill colour/forecast-group
+                   :stroke "none"}]]
+
         [:.witan-pw-header
          {:border-bottom "#ccc 2px solid"}
          [:h1

--- a/src/witan/styles/colours.clj
+++ b/src/witan/styles/colours.clj
@@ -18,6 +18,7 @@
 (def forecast-input "#9fc5f8")
 (def forecast-model "#ffd966")
 (def forecast-output "#b6d7a8")
+(def forecast-group "#c0c5f7")
 
 ;; page background
 (def bg white)

--- a/src/witan/ui/components/forecast.cljs
+++ b/src/witan/ui/components/forecast.cljs
@@ -7,6 +7,7 @@
             [schema.core :as s :include-macros true]
               ;;
             [witan.ui.widgets :as widgets]
+            [witan.ui.components.model-diagram :as model-diagram]
             [witan.schema.core :refer [Forecast]]
             [witan.ui.async :refer [raise!]]
             [witan.ui.refs :as refs]))
@@ -53,10 +54,16 @@
   (render [_]
           (let [{:keys [id action]} (first opts)
                 kaction (keyword action)
-                forecast (some #(if (= (:id %) id) %) (:forecasts cursor))]
+                forecast (some #(if (= (:id %) id) %) (:forecasts cursor))
+                ;; this is directly included in the forecast's data for now. More realistically
+                ;; it would be derived from input and output information in the forecast.
+                model-shape (select-keys forecast [:n-inputs :n-outputs])]
             (html
              [:div
               (om/build header forecast)
+              [:div.pure-g
+               [:div.pure-u-1.witan-model-diagram
+                (om/build model-diagram/diagram model-shape)]]
               (if (not (contains? valid-actions kaction))
                 [:span "Unknown forecast action"]
                 [:div

--- a/src/witan/ui/components/model_diagram.cljs
+++ b/src/witan/ui/components/model_diagram.cljs
@@ -1,0 +1,138 @@
+(ns witan.ui.components.model-diagram
+  (:require [om.core :as om :include-macros true]
+            [om-tools.dom :as dom :include-macros true]
+            [om-tools.core :refer-macros [defcomponent defcomponentmethod]]
+            [thi.ng.geom.svg.core :as svg]
+            [hiccups.runtime :as hiccupsrt])
+  (:require-macros [hiccups.core :as hiccups]))
+
+;; All values will used in SVG without units.
+(def render-options
+  {:box-height        30
+   :box-h-spacing     20
+   :box-width         125
+   :box-w-spacing     75
+   :group-box-padding 6
+   :canvas-width      600
+   :padding           10})
+
+(defn stacked-box
+  "Draws the ith box in a stack starting at (x-offset, y-offset), with class cl."
+  [render-options x-offset y-offset cl i]
+  (let [{:keys [box-height box-width box-h-spacing]} render-options]
+    (svg/rect [x-offset (+ (* (+ box-height box-h-spacing) i) y-offset)]
+              box-width
+              box-height
+              {:class cl})))
+
+(defn stack-of-boxes
+  "Draws a stack of n-boxes boxes starting at x-offset, with y position determined so as to be centred
+  on a stack with max-n boxes in it. Boxes will have class cl."
+  [render-options x-offset max-n n-boxes cl]
+  (let [{:keys [box-height box-h-spacing]} render-options]
+    (mapv (partial stacked-box
+                   render-options
+                   x-offset
+                   (* (/ (+ box-height box-h-spacing) 2)
+                      (- max-n n-boxes))
+                   cl)
+          (range n-boxes))))
+
+(defn stacked-line
+  "Similar to the above, draws the ith line in a stack, starting at y-offset, running from x-start to x-end."
+  [render-options x-start x-end y-offset i]
+  (let [{:keys [box-height box-width box-h-spacing]} render-options
+        line-y (+ (* (+ box-height box-h-spacing) i) (/ box-height 2) y-offset)]
+    (svg/line [x-start line-y] [x-end line-y] {:class "line"})))
+
+(defn stack-of-lines
+  "See stack-of-boxes."
+  [render-options x-start x-end max-n n-lines]
+  (let [{:keys [box-height box-h-spacing]} render-options]
+    (mapv (partial stacked-line
+                   render-options
+                   x-start
+                   x-end
+                   (* (/ (+ box-height box-h-spacing) 2)
+                      (- max-n n-lines)))
+          (range n-lines))))
+
+(defn group-box
+  "Draws a box that groups together a number of boxes. Is drawn relative to a stack of boxes starting at
+  (x-offset, y-offset) containing boxes from i-start to i-end."
+  [render-options x-offset y-offset i-start i-end]
+  (let [{:keys [box-height box-width box-h-spacing group-box-padding]} render-options]
+    (svg/rect [(- x-offset group-box-padding)
+               (- (+ (* (+ box-height box-h-spacing) i-start) y-offset) group-box-padding)]
+              (+ box-width (* 2 group-box-padding))
+              (+ (* (+ box-height box-h-spacing) (- i-end i-start))
+                 (* -1 box-h-spacing)
+                 (* 2 group-box-padding))
+              {:class "group"})))
+
+(defn group-ranges
+  "Given a list of group sizes, gives the start and end indices of each group i.e.
+  [2 2 3] -> ((0 2) (2 4) (4 7)). Used for drawing the output grouping boxes."
+  [n-outputs]
+  (let [c (reductions + 0 n-outputs)]
+    (apply map list [(drop-last c) (rest c)])))
+
+(defn group-boxes
+  "Draws a set of group boxes, specified by group-sizes (see group-ranges)."
+  [render-options x-offset max-n group-sizes]
+  (let [{:keys [box-height box-h-spacing]} render-options
+        ranges (group-ranges group-sizes)
+        n-boxes (apply + group-sizes)]
+    (mapv #(group-box
+            render-options
+            x-offset
+            (* (/ (+ box-height box-h-spacing) 2) (- max-n n-boxes))
+            (first %)
+            (second %))
+          ranges)))
+
+(defn render-model
+  "Draws a digram for a given model specification."
+  [render-options model]
+  (let [{:keys [canvas-width box-width box-w-spacing box-height box-h-spacing padding]} render-options
+        {:keys [n-inputs n-outputs]} model
+        total-outputs (apply + n-outputs)
+        max-n (max n-inputs total-outputs)]
+    (hiccups/html (svg/svg
+                    {:width  (+ canvas-width (* 2 padding))
+                     :height (+ (* max-n (+ box-height box-h-spacing)) (* 2 padding))}
+                    (svg/group
+                      {:transform (str "translate(" padding ", " padding ")")}
+                      (concat
+                        (stack-of-boxes render-options 0 max-n n-inputs "input")
+                        (stack-of-lines render-options
+                                        box-width
+                                        (+ box-width box-w-spacing)
+                                        max-n
+                                        n-inputs)
+                        [(svg/rect [(+ box-width box-w-spacing) 0]
+                                   box-width
+                                   (- (* max-n (+ box-height box-h-spacing)) box-h-spacing)
+                                   {:class "model"})]
+                        (group-boxes
+                          render-options
+                          (* 2 (+ box-width box-w-spacing))
+                          max-n
+                          n-outputs)
+                        (stack-of-boxes render-options
+                                        (* 2 (+ box-width box-w-spacing))
+                                        max-n
+                                        total-outputs
+                                        "output")
+                        (stack-of-lines render-options
+                                        (+ (* 2 box-width) box-w-spacing)
+                                        (* 2 (+ box-width box-w-spacing))
+                                        max-n
+                                        total-outputs)))))))
+
+(defcomponent diagram
+  [model-shape owner]
+  (render [this]
+    (dom/div #js {:style #js {:display "inline-block"}
+                  :dangerouslySetInnerHTML
+                         #js {:__html (render-model render-options model-shape)}})))

--- a/src/witan/ui/data.cljs
+++ b/src/witan/ui/data.cljs
@@ -65,6 +65,8 @@
   (let [forecasts [{:id "1234"
                       :name "Population Forecast for Camden"
                       :type :population
+                      :n-inputs 3
+                      :n-outputs [2 3]
                       :owner "Camden"
                       :version 3
                       :last-modified "Aug 10th, 2015"
@@ -72,6 +74,8 @@
                      {:id "1233"
                       :name "Population Forecast for Camden"
                       :type :population
+                      :n-inputs 3
+                      :n-outputs [2 3]
                       :owner "Camden"
                       :version 2
                       :last-modified "Aug 8th, 2015"
@@ -80,6 +84,8 @@
                      {:id "1232"
                       :name "Population Forecast for Camden"
                       :type :population
+                      :n-inputs 3
+                      :n-outputs [2 3]
                       :owner "Camden"
                       :version 1
                       :last-modified "July 4th, 2015"
@@ -88,6 +94,8 @@
                      {:id "5678"
                       :name "Population Forecast for Bexley"
                       :type :population
+                      :n-inputs 2
+                      :n-outputs [3 1]
                       :owner "Bexley"
                       :version 2
                       :last-modified "July 22nd, 2015"
@@ -95,6 +103,8 @@
                      {:id "5676"
                       :name "Population Forecast for Bexley"
                       :type :population
+                      :n-inputs 2
+                      :n-outputs [3 1]
                       :owner "Bexley"
                       :version 1
                       :last-modified "June 14th, 2015"
@@ -103,6 +113,8 @@
                      {:id "3339"
                       :name "Population Forecast for Hackney"
                       :type :population
+                      :n-inputs 3
+                      :n-outputs [2 2]
                       :owner "Hackney"
                       :version 1
                       :last-modified "Feb 14th, 2015"


### PR DESCRIPTION
Integrates a "static" diagram into the forecast page driven by data added to the forecast map. Static in the sense that it does not respond to clicks or display input/model/output status.

I'm not sure about the structure of the html on the forecast page. I've put the digram in its own `div.pure-g` but that doesn't feel right. Spacing on top of diagram is a bit off, but let's get structure of page clear first.
