### PR TITLE
Animated forecast wizard.

### DIFF
--- a/src/clj/witan/styles/base.clj
+++ b/src/clj/witan/styles/base.clj
@@ -162,6 +162,9 @@
       [:.name
        {:margin-left (em 1)}]]
 
+     [:#witan-pw-top-spacer
+      {:height (em 2)}]
+
      [:.witan-model-diagram
       {:stroke colour/black
        :stroke-width 3
@@ -170,10 +173,20 @@
       [:.output {:fill colour/forecast-output}]
       [:.model {:fill colour/forecast-model}]
       [:.group {:fill colour/forecast-group
-                :stroke "none"}]
-      [:.highlight {:fill "none"
-                    :stroke-width 2
-                    :stroke-dasharray "3,3"}]]
+                :stroke "grey"
+                :stroke-width (px 2)
+                ;;:stroke-dasharray "3,3"
+                }]
+      [:.highlight {:transition "fill 0.5s"
+                    :stroke "none"}]
+      [:.forecast-label-circle {:stroke-weight (px 2)
+                                :fill :none
+                                :transition "stroke 0.5s"}]
+      [:.forecast-label-text {:font-family f/base-fonts
+                              :font-weight :bold
+                              :stroke :none
+                              :transition "fill 0.5s"}]]
+
      [:.witan-pw-header
       {:border-bottom "#ccc 2px solid"}
       [:h1
@@ -182,7 +195,8 @@
 
      [:.witan-pw-nav-button
       ;; I really want this to vertically centre, but can't seem to figure it out
-      {:padding-top (em 8)}
+      {:padding-top (em 8)
+       :text-align :center}
       [:a {:color colour/primary}]]
 
      [:.witan-pw-area-header
@@ -196,10 +210,13 @@
         :font-weight 400}]
       [:.input
        {:width (percent 100)
-        :background-color colour/forecast-input}]
+        :background-color colour/forecast-input
+        :transition "background-color 0.5s"}]
       [:.model
        {:width (percent 100)
-        :background-color colour/forecast-model}]
+        :background-color colour/forecast-model
+        :transition "background-color 0.5s"}]
       [:.output
        {:width (percent 100)
-        :background-color colour/forecast-output}]]])))
+        :background-color colour/forecast-output
+        :transition "background-color 0.5s"}]]])))

--- a/src/cljs/witan/ui/components/forecast.cljs
+++ b/src/cljs/witan/ui/components/forecast.cljs
@@ -77,16 +77,17 @@
       (html
         [:div.pure-g
          (om/build header forecast)
+         [:div.pure-u-1#witan-pw-top-spacer]
          [:div.pure-u-1-12 {:key "forecast-left"}
           [:div.witan-pw-nav-button
            [:a {:href (nav/forecast-wizard {:id id :action (previous-action action)})}
-            [:i.fa.fa-chevron-left.fa-lg]]]]
+            [:i.fa.fa-chevron-left.fa-3x]]]]
          [:div.pure-u-5-6.witan-model-diagram {:key "forecast-centre"}
           (om/build model-diagram/diagram model-conf)]
          [:div.pure-u-1-12 {:key "forecast-right"}
           [:div.witan-pw-nav-button
            [:a {:href (nav/forecast-wizard {:id id :action (next-action action)})}
-            [:i.fa.fa-chevron-right.fa-lg]]]]
+            [:i.fa.fa-chevron-right.fa-3x]]]]
          (if-not (contains? valid-actions kaction)
            [:div.pure-u-1 [:span "Unknown forecast action"]]
            [:div.pure-u-1 {:key "forecast-header"}

--- a/src/cljs/witan/ui/components/model_diagram.cljs
+++ b/src/cljs/witan/ui/components/model_diagram.cljs
@@ -115,7 +115,7 @@
         y-start (* -1 highlight-padding)
         x-size (+ box-width (* 2 highlight-padding))
         y-size (+ (* row-height max-n) (* 2 highlight-padding) (* -1 box-h-spacing) top-offset)
-        fill-colour (if highlighted "#cccccc" "#f8f8f8")]
+        fill-colour (if highlighted "#dddddd" "white")]
     (svg/rect [x-start y-start] x-size y-size
               {:class "highlight"
                :key   (str "highlight-box-" stage-index)


### PR DESCRIPTION
Go for animated fill transitions rather than movement, as I think it looks more classy! Also label stages in forecast wizard diagram.

Note that the colours involved in the transitions are coded into the code that generates the model diagram, rather than in the CSS. Not sure there's a way around this that keeps the transitions working.
