### PR TITLE
Dashboard no longer makes calls to the API service

### DIFF
--- a/src/cljs/witan/ui/services/api.cljs
+++ b/src/cljs/witan/ui/services/api.cljs
@@ -75,7 +75,7 @@
   (POST event "/login" {:username email :password pass} result-ch))
 
 (defmethod service-m
-  :refresh-forecasts
+  :get-forecasts
   [event _ result-ch]
   (GET event "/forecasts" {:user "foobar"} result-ch))
 
@@ -99,11 +99,6 @@
       (log/info "Login failed.")
       (log/debug "Response:" response)
       false)))
-
-(defmethod api-response
-  [:refresh-forecasts :success]
-  [_ response]
-  (venue/publish! :api/forecasts-refreshed response))
 
 (defmethod api-response
   :default

--- a/src/cljs/witan/ui/services/data.cljs
+++ b/src/cljs/witan/ui/services/data.cljs
@@ -83,7 +83,7 @@
 
 (defmethod request-handler
   :filter-forecasts
-  [owner event args ch]
+  [owner event args result-ch]
   (let [forecasts (fetch-forecasts (select-keys args [:expand :filter]))]
     (put! ch [:success {:forecasts forecasts
                         :has-ancestors (->>
@@ -93,7 +93,7 @@
 
 (defmethod request-handler
   :fetch-forecasts
-  [owner event id ch]
+  [owner event id result-ch]
   (venue/request! {:owner owner
                    :service :service/api
                    :request :get-forecasts
@@ -102,7 +102,7 @@
 
 (defmethod request-handler
   :fetch-forecast
-  [owner event id ch]
+  [owner event id result-ch]
   (venue/request! {:owner owner
                    :service :service/api
                    :request :get-forecast
@@ -113,12 +113,12 @@
 
 (defmethod response-handler
   [:get-forecast :success]
-  [owner _ response ch]
+  [owner _ response result-ch]
   (put! ch [:success response]))
 
 (defmethod response-handler
   [:get-forecasts :success]
-  [owner _ forecasts ch]
+  [owner _ forecasts result-ch]
   (log/debug "Received" (count forecasts) "forecasts.")
   (reset-db!)
   (d/transact! db-conn forecasts)


### PR DESCRIPTION
This will be monitored. With the exception of 'login', no requests
should be made directly to the API service from view-models; everything
should go via data.
