### PR TITLE
Extra wiring in order to get the forecast page working

### DIFF
--- a/src/cljs/witan/ui/core.cljs
+++ b/src/cljs/witan/ui/core.cljs
@@ -38,11 +38,11 @@
 
 (venue/defview!
   {:target "app"
-   :route "/forecast/:id/*action"
+   :route "/forecast/:id/:version/*action"
    :id :views/forecast
    :view witan.ui.fixtures.forecast.view/view
    :view-model witan.ui.fixtures.forecast.view-model/view-model
-   :state {}})
+   :state {:forecast nil}})
 
 (venue/defview!
   {:target "app"

--- a/src/cljs/witan/ui/fixtures/dashboard/view.cljs
+++ b/src/cljs/witan/ui/fixtures/dashboard/view.cljs
@@ -38,6 +38,8 @@
   [[selected top-level] owner]
   (render [_]
           (let [selected-id (:forecast/version-id selected)
+                selected-forecast-id (:forecast/forecast-id selected)
+                selected-version (:forecast/version selected)
                 is-top-level? (contains? top-level selected-id)]
             (html
              [:div.pure-menu.pure-menu-horizontal.witan-dash-heading
@@ -57,7 +59,7 @@
                   [:i.fa.fa-plus]]]]
                (if (and (not-empty selected) is-top-level?)
                  [:li.witan-menu-item.pure-menu-item
-                  [:a {:href (venue/get-route :views/forecast {:id selected-id :action "input"})}
+                  [:a {:href (venue/get-route :views/forecast {:id selected-forecast-id :version selected-version :action "input"})}
                    [:button.pure-button.button-error
                     [:i.fa.fa-pencil]]]])
                (if (seq selected)
@@ -67,7 +69,7 @@
                     [:i.fa.fa-copy]]]])
                (if (seq selected)
                  [:li.witan-menu-item.pure-menu-item
-                  [:a {:href (venue/get-route :views/forecast {:id selected-id :action "output"})}
+                  [:a {:href (venue/get-route :views/forecast {:id selected-forecast-id :version selected-version :action "output"})}
                    [:button.pure-button.button-primary
                     [:i.fa.fa-download]]]])
                (if (seq selected)
@@ -103,7 +105,7 @@
                               :opts {:on-click        #(venue/raise! %1 %2 %3)
                                      :on-double-click #(when-not (:forecast/descendant-id %2)
                                                          (goto-window-location!
-                                                          (venue/get-route :views/forecast {:id (:forecast/version-id %2) :action "input"})))}})]]]
+                                                          (venue/get-route :views/forecast {:id (:forecast/forecast-id %2) :version (:forecast/version %2) :action "input"})))}})]]]
             (when (:refreshing? cursor)
               [:div.view-overlay.trans-bg
                [:div#loading

--- a/src/cljs/witan/ui/fixtures/forecast/view.cljs
+++ b/src/cljs/witan/ui/fixtures/forecast/view.cljs
@@ -9,7 +9,8 @@
             [witan.ui.widgets :as widgets]
             [witan.ui.components.model-diagram :as model-diagram]
             [witan.schema.core :refer [Forecast]]
-            [venue.core :as venue]))
+            [venue.core :as venue])
+  (:require-macros [cljs-log.core :as log]))
 
 (def valid-actions
   #{:input
@@ -64,31 +65,34 @@
       [:div "Model view"])))
 
 (defcomponent view
-  [{:keys [id action forecast]} owner]
+  [{:keys [id action forecast version]} owner]
   (render [_]
     (let [kaction (keyword action)
           ;; this is directly included in the forecast's data for now. More realistically
           ;; it would be derived from input and output information in the forecast.
           model-conf (merge {:action kaction} (select-keys forecast [:n-inputs :n-outputs]))]
       (html
-        [:div.pure-g
-         (om/build header forecast)
-         [:div.pure-u-1#witan-pw-top-spacer]
-         [:div.pure-u-1-12 {:key "forecast-left"}
-          [:div.witan-pw-nav-button
-           [:a {:href (venue/get-route :views/forecast {:id id :action (previous-action action)})}
-            [:i.fa.fa-chevron-left.fa-3x]]]]
-         [:div.pure-u-5-6.witan-model-diagram {:key "forecast-centre"}
-          (when forecast (om/build model-diagram/diagram model-conf))]
-         [:div.pure-u-1-12 {:key "forecast-right"}
-          [:div.witan-pw-nav-button
-           [:a {:href (venue/get-route :views/forecast {:id id :action (next-action action)})}
-            [:i.fa.fa-chevron-right.fa-3x]]]]
-         (if-not (contains? valid-actions kaction)
-           [:div.pure-u-1 [:span "Unknown forecast action"]]
-           [:div.pure-u-1 {:key "forecast-header"}
-            [:div.witan-pw-area-header
-             [:div
-              {:class action}
-              [:h2 (i/capitalize action)]]]
-            (om/build action-view [kaction forecast])])]))))
+       (if-not forecast
+         [:div.pure-g
+          [:h1 "LOADING"]]
+         [:div.pure-g
+          (om/build header forecast)
+          [:div.pure-u-1#witan-pw-top-spacer]
+          [:div.pure-u-1-12 {:key "forecast-left"}
+           [:div.witan-pw-nav-button
+            [:a {:href (venue/get-route :views/forecast {:id id :version version :action (previous-action action)})}
+             [:i.fa.fa-chevron-left.fa-3x]]]]
+          [:div.pure-u-5-6.witan-model-diagram {:key "forecast-centre"}
+           (when forecast (om/build model-diagram/diagram model-conf))]
+          [:div.pure-u-1-12 {:key "forecast-right"}
+           [:div.witan-pw-nav-button
+            [:a {:href (venue/get-route :views/forecast {:id id :version version :action (next-action action)})}
+             [:i.fa.fa-chevron-right.fa-3x]]]]
+          (if-not (contains? valid-actions kaction)
+            [:div.pure-u-1 [:span "Unknown forecast action"]]
+            [:div.pure-u-1 {:key "forecast-header"}
+             [:div.witan-pw-area-header
+              [:div
+               {:class action}
+               [:h2 (i/capitalize action)]]]
+             (om/build action-view [kaction forecast])])])))))

--- a/src/cljs/witan/ui/fixtures/forecast/view_model.cljs
+++ b/src/cljs/witan/ui/fixtures/forecast/view_model.cljs
@@ -15,14 +15,15 @@
   [owner cursor])
 
 (defn on-activate
-  [owner {:keys [id action]} cursor]
+  [owner {:keys [id action version]} cursor]
   (om/update! cursor :id id)
-  (om/update! cursor :action action)
+  (om/update! cursor :action (or (not-empty action) "input"))
+  (om/update! cursor :version version)
   (when (data/logged-in?)
     (venue/request! {:owner owner
                      :service :service/data
                      :request :fetch-forecast
-                     :args id
+                     :args {:id id :version version}
                      :context cursor})))
 
 (defmethod response-handler

--- a/src/cljs/witan/ui/fixtures/new_forecast/view_model.cljs
+++ b/src/cljs/witan/ui/fixtures/new_forecast/view_model.cljs
@@ -64,13 +64,13 @@
 
 (defmethod response-handler
   [:add-forecast :success]
-  [owner _ model-id cursor]
+  [owner _ {:keys [forecast-id version] :as fore} cursor]
   (om/update! cursor :working? false)
   (om/update! cursor :success? true)
-  (venue/navigate! :views/forecast {:id model-id :action "input"}))
+  (venue/navigate! :views/forecast {:id forecast-id :version version :action "input"}))
 
 (defmethod response-handler
   [:add-forecast :failure]
-  [owner _ models cursor]
+  [owner _ _ cursor]
   (om/update! cursor :working? false)
   (om/update! cursor :error :add-forecast))

--- a/src/cljs/witan/ui/services/api.cljs
+++ b/src/cljs/witan/ui/services/api.cljs
@@ -65,7 +65,7 @@
   (if-let [token (.get goog.net.cookies token-name)]
     (do
       (reset! api-token token)
-      (GET :token-test "/" {} nil))
+      (GET :token-test "/" nil nil))
     (log/debug "No existing token was found.")))
 
 (defn request-handler
@@ -121,6 +121,11 @@
   :get-models
   [event id result-ch]
   (GET event "/models" nil result-ch))
+
+(defmethod service-m
+  :get-forecast
+  [event {:keys [id version]} result-ch]
+  (GET event (str "/forecasts/" id "/" version) nil result-ch))
 
 (defmethod service-m
   :create-forecast

--- a/src/cljs/witan/ui/services/data.cljs
+++ b/src/cljs/witan/ui/services/data.cljs
@@ -238,7 +238,12 @@
   [:create-forecast :success]
   [owner _ new-forecast result-ch]
   (put-item-into-db! new-forecast :forecast)
-  (put! result-ch [:success (:version-id new-forecast)]))
+  (put! result-ch [:success (select-keys new-forecast [:forecast-id :version])]))
+
+(defmethod response-handler
+  [:get-forecast :success]
+  [owner _ forecast result-ch]
+  (put! result-ch [:success (put-item-into-db! forecast :forecast)]))
 
 ;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
This changes our UI route from `/forecasts/:id` to `/forecasts/:id/:version` in line with the API
