### PR TITLE
Beautify forecast page

### DIFF
--- a/src/clj/witan/styles/base.clj
+++ b/src/clj/witan/styles/base.clj
@@ -26,7 +26,11 @@
       {:font-family f/base-fonts}]
      [:h1
       {:color     colour/title
-       :font-size (em 2.5)}]
+       :font-size (em 2.5)}
+      [:em
+       {:font-size (em 0.70)
+        :color colour/title-light
+        :margin-left (em 0.5)}]]
      [:h2
       {:color     colour/subtitle
        :font-size (em 1.75)}]
@@ -74,6 +78,11 @@
      [:#app
       {:padding "0 1em"}]
 
+     [".unselectable::selection"
+      {:background-color :transparent}]
+
+     ;; buttons
+
      [:.button-success
       {:background-color colour/button-success
        :color            colour/white}]
@@ -94,16 +103,42 @@
       {:background-color colour/button-secondary
        :color            colour/white}]
 
+     ;; text
+
      [:.text-center
       {:text-align :center}]
 
      [:.text-white
       {:color colour/white}]
 
-     [".unselectable::selection"
-      {:background-color :transparent}]
+     ;; labels
 
-         ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+     [:.label-in-progress
+      {:background-color colour/in-progress}]
+
+     [:.label-forecast-changed
+      {:background-color colour/forecast-changed}]
+
+     [:.label-new
+      {:background-color colour/new-forecast}]
+
+     [:.label
+      {:display :inline
+       :padding ".2em .6em .3em"
+       :font-size (percent 75)
+       :font-weight 700
+       :line-height 1
+       :color colour/white
+       :text-align :center
+       :white-space :nowrap
+       :vertical-align :middle
+       :border-radius (em 0.25)
+       :margin-right (em 0.20)}]
+
+     [:.label-small
+      {:font-size (percent 65)}]
+
+     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
      [:#container
       {:margin (em 1)}]
@@ -111,7 +146,8 @@
      ;; witan
 
      [:#witan-menu
-      {:background-color colour/header}]
+      {:background-color colour/header
+       :box-shadow "0px 3px 4px #888888"}]
 
      [:.witan-menu-item
       [:a
@@ -130,17 +166,19 @@
       [:#filter-input
        {:padding-left (px 30)}]]
 
+     [:.witan-page-heading
+      [:.pure-menu-list
+       {:bottom (em 0.55)}]
+      [:button
+       {:margin-left (em 0.5)}]]
+
      [:.witan-dash-heading
       {:color         colour/primary
-       ;;:font-size (px 20)
        :border-bottom "#ccc 2px solid"}
       [:h1
        {:margin-bottom (em 0.2)
         :display       :inline-block}]
-      [:button
-       {:margin-left (em 0.5)}]
-      [:.pure-menu-list
-       {:bottom (em 0.55)}]
+
       [:.pure-form
        {:display        :inline-flex
         :font-size      (px 14)
@@ -167,7 +205,10 @@
        {:background-color colour/white}]
       [:&:hover
        {:background-color colour/row-highlight
-        :cursor           :pointer}]]
+        :cursor           :pointer}]
+      [:.version-labels
+       {:display :inline
+        :margin-left (em 0.5)}]]
 
      [:.witan-forecast-table-row-selected
       :.witan-forecast-table-row-selected:hover
@@ -179,23 +220,72 @@
       [:.name
        {:margin-left (em 1)}]]
 
+     [:.witan-forecast-table-version-descendant
+      {:margin-left (em 0.3)}]
+
      [:#witan-pw-top-spacer
       {:height (em 2)}]
+
+     [:#witan-pw-edits
+      {:background-color colour/forecast-changed-light
+       :border "solid 2px"
+       :border-color colour/forecast-changed
+       :border-radius (em 0.3)
+       :padding (em 1)
+       :line-height (em 1.6)
+       :font-size (em 1.1)}
+      [:#witan-pw-edits-buttons
+       {:text-align :right}]
+      [:button
+       {:margin-left (em 1)}
+       [:&#create
+        {:background-color colour/forecast-changed}]
+       [:&#revert
+        {:background-color colour/button-error}]]]
+
+     [:#witan-pw-in-prog
+      {:background-color colour/in-progress-light
+       :border "solid 2px"
+       :border-color colour/in-progress
+       :border-radius (em 0.3)
+       :padding (em 1)
+       :line-height (em 1.6)
+       :font-size (em 1.1)}
+      [:button
+       {:margin-left (em 1)
+        :display :inline
+        :background-color colour/in-progress
+        }]]
+     [:#witan-pw-in-prog-text
+      {:display :inline}]
+
+     [:#witan-pw-area
+      {:line-height (em 1.6)}]
 
      [:.witan-model-diagram
       {:stroke       colour/black
        :stroke-width 3
        :text-align   "center"}
-      [:.input {:fill colour/forecast-input}]
+      [:.input  {:fill colour/forecast-input}]
       [:.output {:fill colour/forecast-output}]
-      [:.model {:fill colour/forecast-model}]
-      [:.group {:fill         colour/forecast-group
-                :stroke       "grey"
-                :stroke-width (px 2)
-                ;;:stroke-dasharray "3,3"
-}]
-      [:.highlight {:transition "fill 0.5s"
-                    :stroke     "none"}]
+      [:.model  {:fill colour/forecast-model}]
+      [:.group  {:fill         colour/forecast-group
+                 :stroke       "grey"
+                 :stroke-width (px 2)}]
+
+      [:.highlight-input  {:fill colour/forecast-input-light
+                           :transition "stroke 0.5s"
+                           :stroke     "white"}]
+      [:.highlight-output {:fill colour/forecast-output-light
+                           :transition "stroke 0.5s"
+                           :stroke     "white"}]
+      [:.highlight-model  {:fill colour/forecast-model-light
+                           :transition "stroke 0.5s"
+                           :stroke     "white"}]
+
+      [:.highlighted
+       {:stroke "none"}]
+
       [:.forecast-label-circle {:stroke-weight (px 2)
                                 :fill          :none
                                 :transition    "stroke 0.5s"}]
@@ -208,18 +298,30 @@
       {:border-bottom "#ccc 2px solid"}
       [:h1
        {:margin-bottom (em 0.2)
-        :display       :inline-block}]]
+        :display       :inline-block}]
+      [:.version-zero
+       {:color colour/new-forecast}]
+      [:.labels
+       {:display     :inline
+        :margin-left (em 0.5)
+        :font-size (percent 60)}]]
 
      [:.witan-pw-nav-button
-      ;; I really want this to vertically centre, but can't seem to figure it out
-      {:padding-top (em 8)
-       :text-align :center}
-      [:a {:color colour/primary}]]
+      {:text-align :center
+       :color colour/primary
+       :display :block
+       :height :inherit
+       :position :relative}
+      [:i
+       {:top (percent 40)
+        :position :absolute
+        :left (percent 10)
+        :right (percent 10)}]]
 
      [:.witan-pw-area-header
       {:text-align    :center
        :width         (percent 100)
-       :margin-top    (px 20)
+       ;;:margin-top    (px 20)
        :margin-bottom (px 15)}
       [:h2
        {:color       colour/primary

--- a/src/clj/witan/styles/colours.clj
+++ b/src/clj/witan/styles/colours.clj
@@ -17,12 +17,18 @@
 
 ;; aliases
 (def error button-error)
+(def warning button-warning)
 
 ;;
 (def forecast-input "#9fc5f8")
 (def forecast-model "#ffd966")
 (def forecast-output "#b6d7a8")
 (def forecast-group "#c0c5f7")
+(def forecast-changed "#fa8144")
+(def forecast-input-light  (color/lighten forecast-input 12))
+(def forecast-model-light  (color/lighten forecast-model 12))
+(def forecast-output-light (color/lighten forecast-output 12))
+(def forecast-changed-light (color/lighten forecast-changed 12))
 
 ;; page background
 (def bg white)
@@ -41,6 +47,7 @@
 
 ;; title (h1) of the page
 (def title primary)
+(def title-light (color/lighten primary 40))
 
 ;; page subtitle and also h2
 (def subtitle secondary)
@@ -69,3 +76,9 @@
 
 ;; row selected
 (def row-selected (color/darken row-highlight 30))
+
+;; themes
+(def in-progress "#b835f3")
+(def in-progress-light (color/lighten in-progress 20))
+
+(def new-forecast "#ee52d0")

--- a/src/cljs/witan/ui/core.cljs
+++ b/src/cljs/witan/ui/core.cljs
@@ -42,7 +42,8 @@
    :id :views/forecast
    :view witan.ui.fixtures.forecast.view/view
    :view-model witan.ui.fixtures.forecast.view-model/view-model
-   :state {:forecast nil}})
+   :state {:forecast nil
+           :edited-forecast nil}})
 
 (venue/defview!
   {:target "app"

--- a/src/cljs/witan/ui/fixtures/dashboard/view.cljs
+++ b/src/cljs/witan/ui/fixtures/dashboard/view.cljs
@@ -48,65 +48,63 @@
                 (get-string :forecast)]
                (om/build widgets/search-input
                          (str (get-string :filter) " " (->> :forecast
-                                                           get-string
-                                                           i/plural
-                                                           str/lower-case))
-                         {:opts {:on-input #(venue/raise! %1 :event/filter-forecasts %2)}})]
-              [:ul.pure-menu-list
-               [:li.witan-menu-item.pure-menu-item
-                [:a {:href (venue/get-route :views/new-forecast)}
-                 [:button.pure-button.button-success
-                  [:i.fa.fa-plus]]]]
-               (if (and (not-empty selected) is-top-level?)
-                 [:li.witan-menu-item.pure-menu-item
-                  [:a {:href (venue/get-route :views/forecast {:id selected-forecast-id :version selected-version :action "input"})}
-                   [:button.pure-button.button-error
-                    [:i.fa.fa-pencil]]]])
-               (if (seq selected)
-                 [:li.witan-menu-item.pure-menu-item
-                  [:a {:href "#"}
-                   [:button.pure-button.button-warning
-                    [:i.fa.fa-copy]]]])
-               (if (seq selected)
-                 [:li.witan-menu-item.pure-menu-item
-                  [:a {:href (venue/get-route :views/forecast {:id selected-forecast-id :version selected-version :action "output"})}
-                   [:button.pure-button.button-primary
-                    [:i.fa.fa-download]]]])
-               (if (seq selected)
-                 [:li.witan-menu-item.pure-menu-item
-                  [:a {:href (venue/get-route :views/share {:id selected-id})}
-                   [:button.pure-button.button-primary
-                    [:i.fa.fa-share-alt]]]])]]))))
+                                                            get-string
+                                                            i/plural
+                                                            str/lower-case))
+                         {:opts {:on-input #(venue/raise! %1 :event/filter-forecasts %2)}})
+               [:ul.pure-menu-list
+                [:li.witan-menu-item.pure-menu-item
+                 [:a {:href (venue/get-route :views/new-forecast)}
+                  [:button.pure-button.button-success
+                   [:i.fa.fa-plus]]]]
+                (if (and (not-empty selected) is-top-level?)
+                  [:li.witan-menu-item.pure-menu-item
+                   [:a {:href (venue/get-route :views/forecast {:id selected-forecast-id :version selected-version :action "input"})}
+                    [:button.pure-button.button-error
+                     [:i.fa.fa-pencil]]]])
+                (if (seq selected)
+                  [:li.witan-menu-item.pure-menu-item
+                   [:a {:href "#"}
+                    [:button.pure-button.button-warning
+                     [:i.fa.fa-copy]]]])
+                (if (seq selected)
+                  [:li.witan-menu-item.pure-menu-item
+                   [:a {:href (venue/get-route :views/forecast {:id selected-forecast-id :version selected-version :action "output"})}
+                    [:button.pure-button.button-primary
+                     [:i.fa.fa-download]]]])
+                (if (seq selected)
+                  [:li.witan-menu-item.pure-menu-item
+                   [:a {:href (venue/get-route :views/share {:id selected-id})}
+                    [:button.pure-button.button-primary
+                     [:i.fa.fa-share-alt]]]])]]]))))
 
 (defcomponent view
   [cursor owner]
   (render [_]
           (html
-           [:div
-            [:div#forecasts-view
-             (om/build header [(get-selected-forecast cursor)
-                               (->> :forecasts
-                                    cursor
-                                    (remove :forecast/descendant-id)
-                                    (map :forecast/version-id)
-                                    set)])
-             [:table.pure-table.pure-table-horizontal#witan-dash-forecast-list
-              [:thead
-               [:th {:key "forecast-tree"}] ;; empty, for the tree icon
-               [:th {:key "forecast-name"} (get-string :forecast-name)]
-               (for [x [:forecast-owner
-                        :forecast-version
-                        :forecast-lastmodified]]
-                 [:th.text-center {:key (name x)} (get-string x)])]
-              [:tbody
-               (om/build-all widgets/forecast-tr
-                             (map #(as-forecast-tr cursor %) (:forecasts cursor))
-                             {:key  :forecast/version-id
-                              :opts {:on-click        #(venue/raise! %1 %2 %3)
-                                     :on-double-click #(when-not (:forecast/descendant-id %2)
-                                                         (goto-window-location!
-                                                          (venue/get-route :views/forecast {:id (:forecast/forecast-id %2) :version (:forecast/version %2) :action "input"})))}})]]]
-            (when (:refreshing? cursor)
-              [:div.view-overlay.trans-bg
-               [:div#loading
-                [:i.fa.fa-refresh.fa-2x.fa-spin]]])])))
+           (if (:refreshing? cursor)
+             [:i.fa.fa-refresh.fa-spin]
+             [:div
+              [:div#forecasts-view
+               (om/build header [(get-selected-forecast cursor)
+                                 (->> :forecasts
+                                      cursor
+                                      (remove :forecast/descendant-id)
+                                      (map :forecast/version-id)
+                                      set)])
+               [:table.pure-table.pure-table-horizontal#witan-dash-forecast-list
+                [:thead
+                 [:th {:key "forecast-tree"}] ;; empty, for the tree icon
+                 (for [[x width class] [[:forecast-name "35%"]
+                                        [:forecast-owner "25%" "text-center"]
+                                        [:forecast-version "20%"]
+                                        [:forecast-lastmodified "20%" "text-center"]]]
+                   [:th {:key (name x) :class class :style {:width width}} (get-string x)])]
+                [:tbody
+                 (om/build-all widgets/forecast-tr
+                               (map #(as-forecast-tr cursor %) (:forecasts cursor))
+                               {:key  :forecast/version-id
+                                :opts {:on-click        #(venue/raise! %1 %2 %3)
+                                       :on-double-click #(when-not (:forecast/descendant-id %2)
+                                                           (goto-window-location!
+                                                            (venue/get-route :views/forecast {:id (:forecast/forecast-id %2) :version (:forecast/version %2) :action "input"})))}})]]]]))))

--- a/src/cljs/witan/ui/fixtures/forecast/view.cljs
+++ b/src/cljs/witan/ui/fixtures/forecast/view.cljs
@@ -37,14 +37,14 @@
   [{:keys [forecast/name forecast/version forecast/version-id forecast/in-progress? edited?]} owner]
   (render [_]
           (let [new? (= version 0)]
-            (log/debug "NEW" new?)
             (html
              [:div.pure-menu.pure-menu-horizontal.witan-pw-header
               [:div.witan-page-heading
                [:h1 name
-                [:em {:class (when new? "version-zero")}
+                [:em {:class (when new? "version-zero") :key "witan-pw-version"}
                  (get-string :forecast-version " " version)]
                 [:div.labels
+                 {:key "witan-pw-header-labels"}
                  (when in-progress?
                    [:span.label.label-in-progress.label-small (get-string :in-progress)])
                  (when new?

--- a/src/cljs/witan/ui/fixtures/forecast/view.cljs
+++ b/src/cljs/witan/ui/fixtures/forecast/view.cljs
@@ -1,98 +1,186 @@
 (ns ^:figwheel-always witan.ui.fixtures.forecast.view
-  (:require [om.core :as om :include-macros true]
-            [om-tools.dom :as dom :include-macros true]
-            [om-tools.core :refer-macros [defcomponent defcomponentmethod]]
-            [sablono.core :as html :refer-macros [html]]
-            [inflections.core :as i]
-            [schema.core :as s :include-macros true]
-    ;;
-            [witan.ui.widgets :as widgets]
-            [witan.ui.components.model-diagram :as model-diagram]
-            [witan.schema.core :refer [Forecast]]
-            [venue.core :as venue])
-  (:require-macros [cljs-log.core :as log]))
+    (:require [om.core :as om :include-macros true]
+              [om-tools.dom :as dom :include-macros true]
+              [om-tools.core :refer-macros [defcomponent defcomponentmethod]]
+              [sablono.core :as html :refer-macros [html]]
+              [inflections.core :as i]
+              [schema.core :as s :include-macros true]
+              ;;
+              [witan.ui.widgets :as widgets]
+              [witan.ui.strings :refer [get-string]]
+              [witan.ui.components.model-diagram :as model-diagram]
+              [witan.schema.core :refer [Forecast]]
+              [venue.core :as venue])
+    (:require-macros [cljs-log.core :as log]))
 
 (def valid-actions
-  #{:input
-    :output
-    :model})
+  {:input  [nil :model]
+   :output [:model nil]
+   :model  [:input :output]})
+
 
 ;; There's probably a more elegant way to do this
 (defn next-action
-  [action]
-  (case action
-    "input" "model"
-    "model" "output"
-    "output" "output"))
+  [kaction]
+  (-> valid-actions
+      (get kaction)
+      second))
 
 (defn previous-action
-  [action]
-  (case action
-    "input" "input"
-    "model" "input"
-    "output" "model"))
+  [kaction]
+  (-> valid-actions
+      (get kaction)
+      first))
 
 (defcomponent
   header
-  [forecast owner]
+  [{:keys [forecast/name forecast/version forecast/version-id forecast/in-progress? edited?]} owner]
   (render [_]
-    (html
-      [:div.pure-u-1.witan-pw-header {:key "witan-pw-header"} ;; this key doesn't currently appear
-       [:h1 (:name forecast)]])))
+          (let [new? (= version 0)]
+            (log/debug "NEW" new?)
+            (html
+             [:div.pure-menu.pure-menu-horizontal.witan-pw-header
+              [:div.witan-page-heading
+               [:h1 name
+                [:em {:class (when new? "version-zero")}
+                 (get-string :forecast-version " " version)]
+                [:div.labels
+                 (when in-progress?
+                   [:span.label.label-in-progress.label-small (get-string :in-progress)])
+                 (when new?
+                   [:span.label.label-new.label-small (get-string :new)])
+                 (when edited?
+                   [:span.label.label-forecast-changed.label-small (get-string :changed)])]]
+               [:ul.pure-menu-list
+                [:li.witan-menu-item.pure-menu-item
+                 [:a {:href (venue/get-route :views/share {:id 123})}
+                  [:button.pure-button.button-success
+                   [:i.fa.fa-tag]]]]
+                [:li.witan-menu-item.pure-menu-item
+                 [:a {:href (venue/get-route :views/share {:id 123})}
+                  [:button.pure-button.button-primary
+                   [:i.fa.fa-share-alt]]]]]]]))))
 
 (defmulti action-view
-          (fn [[action forecast] owner] action))
+  (fn [[action forecast] owner] action))
 
 (defcomponentmethod action-view
   :input
   [[action forecast] owner]
   (render [_]
-    (html
-      [:div "Input view"])))
+          (html
+           [:div
+            [:p (get-string :input-intro)]])))
 
 (defcomponentmethod action-view
   :output
   [[action forecast] owner]
   (render [_]
-    (html
-      [:div "Output view"])))
+          (html
+           [:div
+            [:p (get-string :output-intro)]])))
 
 (defcomponentmethod action-view
   :model
   [[action forecast] owner]
   (render [_]
-    (html
-      [:div "Model view"])))
+          (html
+           [:div
+            [:p (get-string :model-intro)]])))
 
 (defcomponent view
-  [{:keys [id action forecast version]} owner]
+  [{:keys [id action forecast version edited-forecast]} owner]
   (render [_]
-    (let [kaction (keyword action)
-          ;; this is directly included in the forecast's data for now. More realistically
-          ;; it would be derived from input and output information in the forecast.
-          model-conf (merge {:action kaction} (select-keys forecast [:n-inputs :n-outputs]))]
-      (html
-       (if-not forecast
-         [:div.pure-g
-          [:h1 "LOADING"]]
-         [:div.pure-g
-          (om/build header forecast)
-          [:div.pure-u-1#witan-pw-top-spacer]
-          [:div.pure-u-1-12 {:key "forecast-left"}
-           [:div.witan-pw-nav-button
-            [:a {:href (venue/get-route :views/forecast {:id id :version version :action (previous-action action)})}
-             [:i.fa.fa-chevron-left.fa-3x]]]]
-          [:div.pure-u-5-6.witan-model-diagram {:key "forecast-centre"}
-           (when forecast (om/build model-diagram/diagram model-conf))]
-          [:div.pure-u-1-12 {:key "forecast-right"}
-           [:div.witan-pw-nav-button
-            [:a {:href (venue/get-route :views/forecast {:id id :version version :action (next-action action)})}
-             [:i.fa.fa-chevron-right.fa-3x]]]]
-          (if-not (contains? valid-actions kaction)
-            [:div.pure-u-1 [:span "Unknown forecast action"]]
-            [:div.pure-u-1 {:key "forecast-header"}
-             [:div.witan-pw-area-header
-              [:div
-               {:class action}
-               [:h2 (i/capitalize action)]]]
-             (om/build action-view [kaction forecast])])])))))
+          (let [kaction (keyword action)
+                ;; this is directly included in the forecast's data for now. More realistically
+                ;; it would be derived from input and output information in the forecast.
+                model-conf (merge {:action kaction} (select-keys forecast [:n-inputs :n-outputs]))
+                next-action (next-action kaction)
+                prev-action (previous-action kaction)
+                in-progress? (:forecast/in-progress? forecast)]
+            (html
+             (if-not forecast
+               [:i.fa.fa-refresh.fa-spin]
+               [:div
+                [:div
+                 {:key "witan-pw-header-container"}
+                 (om/build header (assoc forecast :edited? (-> edited-forecast nil? not)))]
+                [:div.pure-g
+                 {:key "witan-pw-body"}
+                 [:div.pure-u-1#witan-pw-top-spacer
+                  {:key "witan-pw-top-spacer"}]
+                 [:a.pure-u-1-12.witan-pw-nav-button
+                  (merge {:key (str "forecast-left-" prev-action)}
+                         (when prev-action
+                           {:href (venue/get-route :views/forecast {:id id :version version :action (name prev-action)})}))
+                  (when prev-action [:i.fa.fa-chevron-left.fa-3x])]
+                 [:div.pure-u-5-6.witan-model-diagram {:key "forecast-centre"}
+                  (when forecast (om/build model-diagram/diagram model-conf))]
+                 [:a.pure-u-1-12.witan-pw-nav-button
+                  (merge {:key (str "forecast-right-" next-action)}
+                         (when next-action
+                           {:href (venue/get-route :views/forecast {:id id :version version :action (name next-action)})}))
+                  (when next-action [:i.fa.fa-chevron-right.fa-3x])]]
+
+                (if in-progress?
+                  [:div.pure-g#witan-pw-in-prog
+                   {:key "witan-pw-in-prog"}
+                   [:div.pure-u-1#witan-pw-in-prog-text
+                    {:key "witan-pw-in-prog-text"}
+                    [:span
+                     {:key "witan-pw-in-prog-text-span"}
+                     (get-string :forecast-in-progress-text)]
+                    [:button.pure-button#refresh
+                     {:key "witan-pw-in-prog-button-refresh"
+                      :on-click #(do
+                                   (venue/raise! owner :refresh-forecast)
+                                   (.preventDefault %))}
+                     [:span
+                      [:i.fa.fa-refresh {:key "witan-pw-in-prog-button-refresh-i"}]
+                      [:span {:key "witan-pw-in-prog-button-refresh-span"}
+                       (str " " (get-string :refresh-now))]]]]]
+
+                  ;; only show edited if not in-progress?
+                  (when edited-forecast
+                    [:div.pure-g#witan-pw-edits
+                     {:key "witan-pw-edits"}
+                     [:div.pure-u-1-2#witan-pw-edits-text
+                      {:key "witan-pw-edits-text"}
+                      [:span (get-string :forecast-changes-text)]]
+                     [:div.pure-u-1-2#witan-pw-edits-buttons
+                      {:key "witan-pw-edits-buttons"}
+                      [:button.pure-button#create
+                       {:key "witan-pw-edits-button-create"}
+                       [:span
+                        [:i.fa.fa-thumbs-o-up {:key "witan-pw-edits-button-create-i"}]
+                        [:span {:key "witan-pw-edits-button-create-span"}
+                         (str " " (get-string :create-new-forecast))]]]
+                      [:button.pure-button#revert
+                       {:key "witan-pw-edits-button-revert"
+                        :on-click #(do
+                                     (venue/raise! owner :revert-forecast)
+                                     (.preventDefault %))}
+                       [:span
+                        [:i.fa.fa-undo {:key "witan-pw-edits-button-revert-i"}]
+                        [:span {:key "witan-pw-edits-button-revert-span"}
+                         (str " " (get-string :revert-forecast))]]]]]))
+
+                [:div.pure-g
+                 {:key "witan-pw-area-container"}
+                 (if-not (contains? (set (keys valid-actions)) kaction)
+                   [:div.pure-u-1 [:span "Unknown forecast action"]]
+                   [:div.pure-u-1.witan-pw-area-header
+                    {:key "witan-pw-area-header"}
+                    [:div
+                     {:class action
+                      :key (str action "-key")}
+                     [:h2 (let [action-name (i/capitalize action)]
+                            (if (= action "model")
+                              action-name
+                              (i/plural action-name)))
+                      (when in-progress?
+                        [:i.fa.fa-lock {:key (str action "-locked-key")
+                                        :style {:margin-left "0.6em"}}])]]
+                    [:div#witan-pw-area
+                     {:key "witan-pw-area"}
+                     (om/build action-view [kaction forecast])]])]])))))

--- a/src/cljs/witan/ui/fixtures/forecast/view_model.cljs
+++ b/src/cljs/witan/ui/fixtures/forecast/view_model.cljs
@@ -30,3 +30,13 @@
   [:fetch-forecast :success]
   [owner _ forecast cursor]
   (om/update! cursor :forecast forecast))
+
+(defmethod event-handler
+  :revert-forecast
+  [owner _ _ cursor]
+  (om/update! cursor :edited-forecast nil))
+
+(defmethod event-handler
+  :refresh-forecast
+  [owner _ _ cursor]
+  (.reload (.-location js/window)))

--- a/src/cljs/witan/ui/services/data.cljs
+++ b/src/cljs/witan/ui/services/data.cljs
@@ -38,7 +38,8 @@
                      (util/map-add-ns ns)
                      (into {}))
         with-db-id (assoc cleaned :db/id db-id)]
-    (d/transact! db-conn [with-db-id])))
+    (d/transact! db-conn [with-db-id])
+    with-db-id))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/cljs/witan/ui/services/mock_api.cljs
+++ b/src/cljs/witan/ui/services/mock_api.cljs
@@ -9,7 +9,7 @@
      :name "My Forecast 1",
      :created "2015-10-06T12:44:17.176-00:00",
      :version-id "78b1bf97-0ebe-42ef-8031-384e504cf795",
-     :in-progress? false,
+     :in-progress? true,
      :forecast-id "fd44474d-e0f8-4713-bacf-299e503e4f30",
      :version 2,
      :owner "cac4ba3a-07c8-4e79-9ae0-d97317bb0d45"}
@@ -35,7 +35,7 @@
      :version 2,
      :created "2015-10-14T08:41:21.477-00:00",
      :description "Description of my forecast",
-     :in-progress? false,
+     :in-progress? true,
      :name "My Forecast 1",
      :owner "d8fc0f3c-0535-4959-bf9e-505af9a59ad9",
      :version-id "78b1bf97-0ebe-42ef-8031-384e504cf795"}

--- a/src/cljs/witan/ui/strings.cljs
+++ b/src/cljs/witan/ui/strings.cljs
@@ -36,13 +36,27 @@
    :create                        "Create"
    :logout                        "Log Out"
    :no-model-properties           "This model has no properties to configure"
+   :please-wait                   "Please Wait..."
+   :create-new-forecast           "Create a New Version"
+   :revert-forecast               "Revert changes"
+   :in-progress                   "In-Progress"
+   :changed                       "Changed"
+   :refresh-now                   "Refresh"
+   :new                           "New"
+   :forecast-changes-text         "There are changes to this forecast. Would you like to save them and create a new version?"
+   :forecast-in-progress-text     "This version is currently being generated. During this time you will be unable to make changes or download results. This can take several minutes."
+   :input-intro                   "The fields below show the inputs that currently configured for this forecast. If there are required inputs, these need to be specified before the model can be run. You can adjust existing inputs in the same way and this will cause the model to be re-run."
+   :model-intro                   "These are the model details that have been configured for this forecast."
+   :output-intro                  "Download the latest results of this forecast."
    })
 
 (defn get-string
   ""
-  [keywd]
+  [keywd & add]
   (if (contains? strings keywd)
-    (keywd strings)
+    (if add
+      (str (keywd strings) (first add) (clojure.string/join " " (concat " " (rest add))))
+      (keywd strings))
     (do
       (log/severe "Failed to find string " (str keywd))
       "## ERROR ##")))

--- a/src/cljs/witan/ui/widgets.cljs
+++ b/src/cljs/witan/ui/widgets.cljs
@@ -71,13 +71,19 @@
               [:td
                {:style {:padding-left "2em"}}
                [:span.unselectable
-                {:class (when has-descendant? "witan-forecast-table-version-descendant")}
+                {:class (when has-descendant? "witan-forecast-table-version-descendant")
+                 :key "witan-forecast-table-version-key"}
                 (:forecast/version forecast)]
                (when (or new? in-progress?)
                  [:div.version-labels
+                  {:key "witan-forecast-table-labels-key"}
                   (when in-progress?
-                    [:span.unselectable.label.label-in-progress.label-small (get-string :in-progress)])
+                    [:span.unselectable.label.label-in-progress.label-small
+                     {:key "witan-forecast-table-labels-in-prog-key"}
+                     (get-string :in-progress)])
                   (when new?
-                    [:span.unselectable.label.label-new.label-small (get-string :new)])])]
+                    [:span.unselectable.label.label-new.label-small
+                     {:key "witan-forecast-table-label-new-key"}
+                     (get-string :new)])])]
               [:td.text-center
                [:span.unselectable (:forecast/created forecast)]]]))))

--- a/src/cljs/witan/ui/widgets.cljs
+++ b/src/cljs/witan/ui/widgets.cljs
@@ -1,11 +1,12 @@
 (ns ^:figwheel-always witan.ui.widgets
-  (:require [om.core :as om :include-macros true]
-            [om-tools.dom :as dom :include-macros true]
-            [om-tools.core :refer-macros [defcomponent]]
-            [sablono.core :as html :refer-macros [html]]
-            [inflections.core :as i]
-            [witan.ui.util :refer [contains-str]])
-  (:require-macros [cljs-log.core :as log]))
+    (:require [om.core :as om :include-macros true]
+              [om-tools.dom :as dom :include-macros true]
+              [om-tools.core :refer-macros [defcomponent]]
+              [sablono.core :as html :refer-macros [html]]
+              [inflections.core :as i]
+              [witan.ui.util :refer [contains-str]]
+              [witan.ui.strings :refer [get-string]])
+    (:require-macros [cljs-log.core :as log]))
 
 ;; search input
 (defcomponent
@@ -36,27 +37,29 @@
                         has-ancestor?
                         is-expanded?
                         has-descendant?]} forecast
-                classes [[is-selected-forecast? "witan-forecast-table-row-selected"]
-                         [has-descendant? "witan-forecast-table-row-descendant"]]]
+                        classes [[is-selected-forecast? "witan-forecast-table-row-selected"]
+                                 [has-descendant? "witan-forecast-table-row-descendant"]]
+                        in-progress? (:forecast/in-progress? forecast)
+                        new? (= (:forecast/version forecast) 0)]
             (html
              [:tr.witan-forecast-table-row {:key (:forecast/version-id forecast)
-                                              :class (->> classes
-                                                          (filter first)
-                                                          (map second)
-                                                          (interpose " ")
-                                                          (apply str))
-                                              :on-click (fn [e]
-                                                          (if (fn? on-click)
-                                                            (if (and
-                                                                 has-ancestor?
-                                                                 (contains-str (.. e -target -className) "tree-control"))
-                                                              (on-click owner :event/toggle-tree-view forecast e)
-                                                              (on-click owner :event/select-forecast forecast e)))
-                                                          (.preventDefault e))
-                                              :on-double-click (fn [e]
-                                                                 (if (fn? on-double-click)
-                                                                   (on-double-click owner forecast e))
-                                                                 (.preventDefault e))}
+                                            :class (->> classes
+                                                        (filter first)
+                                                        (map second)
+                                                        (interpose " ")
+                                                        (apply str))
+                                            :on-click (fn [e]
+                                                        (if (fn? on-click)
+                                                          (if (and
+                                                               has-ancestor?
+                                                               (contains-str (.. e -target -className) "tree-control"))
+                                                            (on-click owner :event/toggle-tree-view forecast e)
+                                                            (on-click owner :event/select-forecast forecast e)))
+                                                        (.preventDefault e))
+                                            :on-double-click (fn [e]
+                                                               (if (fn? on-double-click)
+                                                                 (on-double-click owner forecast e))
+                                                               (.preventDefault e))}
 
               [:td.tree-control (cond
                                   is-expanded? [:i.fa.fa-minus-square-o.tree-control]
@@ -64,8 +67,17 @@
               [:td
                [:span.name.unselectable (:forecast/name forecast)]]
               [:td.text-center
-               [:span.unselectable (:forecast/owner forecast)]]
-              [:td.text-center
-               [:span.unselectable (:forecast/version forecast)]]
+               [:span.unselectable (:forecast/owner-name forecast)]]
+              [:td
+               {:style {:padding-left "2em"}}
+               [:span.unselectable
+                {:class (when has-descendant? "witan-forecast-table-version-descendant")}
+                (:forecast/version forecast)]
+               (when (or new? in-progress?)
+                 [:div.version-labels
+                  (when in-progress?
+                    [:span.unselectable.label.label-in-progress.label-small (get-string :in-progress)])
+                  (when new?
+                    [:span.unselectable.label.label-new.label-small (get-string :new)])])]
               [:td.text-center
                [:span.unselectable (:forecast/created forecast)]]]))))


### PR DESCRIPTION
- Adds labels for 'in-progress', 'new' and 'changed' on the dash and forecast header
- Adds info boxes with buttons for 'in-progress' and 'changed' in forecast page
- New strings
- Owner names now used, rather than owner ID on dash
- Removed unwanted table scaling
- Tweaked colours for differentiation
