### PR TITLE
Ensure correct inputs are displayed at all times

### DIFF
--- a/src/clj/witan/styles/base.clj
+++ b/src/clj/witan/styles/base.clj
@@ -282,15 +282,17 @@
      [:#witan-pw-top-spacer
       {:height (em 1)}]
 
-     [:#witan-pw-edits
-      {:background-color colour/forecast-changed-light
-       :border "solid 2px"
-       :border-color colour/forecast-changed
+     [:.witan-pw-message-box
+      {:border "solid 2px"
        :border-radius (em 0.2)
        :padding (em 0.5)
        :line-height (em 1.6)
        :font-size (em 1.1)
-       :margin-bottom (em 1)}
+       :margin-bottom (em 1)}]
+
+     [:#witan-pw-edits
+      {:background-color colour/forecast-changed-light
+       :border-color colour/forecast-changed}
       [:#witan-pw-edits-text
        {:text-align :left
         :margin "auto 0px"
@@ -310,12 +312,7 @@
      [:#witan-pw-in-prog
       {:background-color colour/in-progress-light
        :border "solid 2px"
-       :border-color colour/in-progress
-       :border-radius (em 0.2)
-       :padding (em 0.5)
-       :line-height (em 1.6)
-       :font-size (em 1.1)
-       :margin-bottom (em 1)}
+       :border-color colour/in-progress}
       [:button
        {:margin-left (em 1)
         :display :inline
@@ -325,6 +322,14 @@
      [:#witan-pw-in-prog-text
       {:display :inline
        :color colour/white}]
+
+     [:#witan-pw-missing
+      {:background-color colour/error-light
+       :border-color colour/error}
+      [:#witan-pw-missing-text
+       {:text-align :center
+        :margin "auto 0px"
+        :height (percent 50)}]]
 
      [:#witan-pw-area
       {:line-height (em 1.6)}]

--- a/src/clj/witan/styles/colours.clj
+++ b/src/clj/witan/styles/colours.clj
@@ -14,6 +14,7 @@
 (def success (rgb 14 173 105))
 (def normal  (rgb 4 139 168))
 (def deep    (rgb 29 53 87))
+(def error-light (color/lighten error 20))
 
 ;;
 (def button-success   success)

--- a/src/cljs/witan/ui/core.cljs
+++ b/src/cljs/witan/ui/core.cljs
@@ -47,6 +47,7 @@
    :state {:id                   nil
            :forecast             nil
            :edited-forecast      nil
+           :missing-required     #{}
            :model                nil
            :browsing-input       nil
            :upload-file          nil

--- a/src/cljs/witan/ui/fixtures/forecast/input_view.cljs
+++ b/src/cljs/witan/ui/fixtures/forecast/input_view.cljs
@@ -289,7 +289,7 @@
   (render [_]
           (html
            (let [current-forecast-inputs (or (:forecast/inputs edited-forecast)
-                                      (:forecast/inputs forecast))
+                                             (:forecast/inputs forecast))
                  inputs     (sort-by
                              :category
                              (util/squash-maps (:model/input-data model) current-forecast-inputs :category))

--- a/src/cljs/witan/ui/fixtures/forecast/input_view.cljs
+++ b/src/cljs/witan/ui/fixtures/forecast/input_view.cljs
@@ -288,12 +288,11 @@
   [[action {:keys [edited-forecast forecast model browsing-input] :as cursor}] owner]
   (render [_]
           (html
-           (let [inputs     (sort-by
+           (let [current-forecast-inputs (or (:forecast/inputs edited-forecast)
+                                      (:forecast/inputs forecast))
+                 inputs     (sort-by
                              :category
-                             (or
-                              (:forecast/inputs edited-forecast)
-                              (:forecast/inputs forecast)
-                              (:model/input-data model)))
+                             (util/squash-maps (:model/input-data model) current-forecast-inputs :category))
                  first-input (first inputs)
                  rest-inputs (rest inputs)]
              [:div

--- a/src/cljs/witan/ui/fixtures/forecast/view.cljs
+++ b/src/cljs/witan/ui/fixtures/forecast/view.cljs
@@ -109,8 +109,69 @@
                [:h2 (get-string :forecast-version)]
                [:h3.model-value 2]]]]])))
 
+(defcomponent in-progress-message
+  [cursor owner]
+  (render [_]
+          (html
+           [:div.pure-g.witan-pw-message-box#witan-pw-in-prog
+            {:key "witan-pw-in-prog"}
+            [:div.pure-u-1#witan-pw-in-prog-text
+             {:key "witan-pw-in-prog-text"}
+             [:span
+              {:key "witan-pw-in-prog-text-span"}
+              (get-string :forecast-in-progress-text)]
+             [:button.pure-button#refresh
+              {:key "witan-pw-in-prog-button-refresh"
+               :on-click #(do
+                            (venue/raise! owner :refresh-forecast)
+                            (.preventDefault %))}
+              [:span
+               [:i.fa.fa-refresh {:key "witan-pw-in-prog-button-refresh-i"}]
+               [:span {:key "witan-pw-in-prog-button-refresh-span"}
+                (str " " (get-string :refresh-now))]]]]])))
+
+(defcomponent edited-forecast-message
+  [cursor owner]
+  (render [_]
+          (html
+           [:div.pure-g.witan-pw-message-box#witan-pw-edits
+            {:key "witan-pw-edits"}
+            [:div.pure-u-1-2#witan-pw-edits-text
+             {:key "witan-pw-edits-text"}
+             [:span (get-string :forecast-changes-text)]]
+            [:div.pure-u-1-2#witan-pw-edits-buttons
+             {:key "witan-pw-edits-buttons"}
+             [:button.pure-button#create
+              {:key "witan-pw-edits-button-create"
+               :on-click #(do (venue/raise! owner :create-forecast-version)
+                              (.preventDefault %))}
+              [:span
+               [:i.fa.fa-thumbs-o-up {:key "witan-pw-edits-button-create-i"}]
+               [:span {:key "witan-pw-edits-button-create-span"}
+                (str " " (get-string :create-new-forecast))]]]
+             [:button.pure-button#revert
+              {:key "witan-pw-edits-button-revert"
+               :on-click #(do
+                            (venue/raise! owner :revert-forecast)
+                            (.preventDefault %))}
+              [:span
+               [:i.fa.fa-undo {:key "witan-pw-edits-button-revert-i"}]
+               [:span {:key "witan-pw-edits-button-revert-span"}
+                (str " " (get-string :revert-forecast))]]]]])))
+
+(defcomponent missing-required-message
+  [cursor owner]
+  (render [_]
+          (html
+           [:div.pure-g.witan-pw-message-box#witan-pw-missing
+            {:key "witan-pw-missing"}
+            [:div.pure-u-1#witan-pw-missing-text
+             {:key "witan-pw-missing-text"}
+             [:span (get-string :missing-required-inputs)]]
+            ])))
+
 (defcomponent view
-  [{:keys [id action forecast version edited-forecast error? model creating?] :as cursor} owner]
+  [{:keys [id action forecast version edited-forecast error? model creating? missing-required] :as cursor} owner]
   (render [_]
           (let [kaction (keyword action)
                 model-conf  {:action kaction
@@ -152,49 +213,13 @@
                     (when next-action [:i.fa.fa-chevron-right.fa-3x])]]
 
                   (if in-progress?
-                    [:div.pure-g#witan-pw-in-prog
-                     {:key "witan-pw-in-prog"}
-                     [:div.pure-u-1#witan-pw-in-prog-text
-                      {:key "witan-pw-in-prog-text"}
-                      [:span
-                       {:key "witan-pw-in-prog-text-span"}
-                       (get-string :forecast-in-progress-text)]
-                      [:button.pure-button#refresh
-                       {:key "witan-pw-in-prog-button-refresh"
-                        :on-click #(do
-                                     (venue/raise! owner :refresh-forecast)
-                                     (.preventDefault %))}
-                       [:span
-                        [:i.fa.fa-refresh {:key "witan-pw-in-prog-button-refresh-i"}]
-                        [:span {:key "witan-pw-in-prog-button-refresh-span"}
-                         (str " " (get-string :refresh-now))]]]]]
+                    (om/build in-progress-message {})
 
                     ;; only show edited if not in-progress?
                     (when edited-forecast
-                      [:div.pure-g#witan-pw-edits
-                       {:key "witan-pw-edits"}
-                       [:div.pure-u-1-2#witan-pw-edits-text
-                        {:key "witan-pw-edits-text"}
-                        [:span (get-string :forecast-changes-text)]]
-                       [:div.pure-u-1-2#witan-pw-edits-buttons
-                        {:key "witan-pw-edits-buttons"}
-                        [:button.pure-button#create
-                         {:key "witan-pw-edits-button-create"
-                          :on-click #(do (venue/raise! owner :create-forecast-version)
-                                         (.preventDefault %))}
-                         [:span
-                          [:i.fa.fa-thumbs-o-up {:key "witan-pw-edits-button-create-i"}]
-                          [:span {:key "witan-pw-edits-button-create-span"}
-                           (str " " (get-string :create-new-forecast))]]]
-                        [:button.pure-button#revert
-                         {:key "witan-pw-edits-button-revert"
-                          :on-click #(do
-                                       (venue/raise! owner :revert-forecast)
-                                       (.preventDefault %))}
-                         [:span
-                          [:i.fa.fa-undo {:key "witan-pw-edits-button-revert-i"}]
-                          [:span {:key "witan-pw-edits-button-revert-span"}
-                           (str " " (get-string :revert-forecast))]]]]]))
+                      (if (empty? missing-required)
+                        (om/build edited-forecast-message {})
+                        (om/build missing-required-message {}))))
 
                   [:div.pure-g
                    {:key "witan-pw-area-container"}

--- a/src/cljs/witan/ui/services/api.cljs
+++ b/src/cljs/witan/ui/services/api.cljs
@@ -138,7 +138,8 @@
   [event forecast result-ch]
   (let [inputs (hash-map :inputs (into {} (map (fn [{:keys [category selected]}]
                                                  (let [selected-req (select-keys selected [:file-name :name :s3-key])]
-                                                   (hash-map category selected-req)))
+                                                   (when (not-empty selected-req)
+                                                     (hash-map category selected-req))))
                                                (:forecast/inputs forecast))))]
     (POST event (util/str-fmt-map "/forecasts/{{id}}/versions" {:id (:forecast/forecast-id forecast)}) inputs result-ch)))
 

--- a/src/cljs/witan/ui/services/data.cljs
+++ b/src/cljs/witan/ui/services/data.cljs
@@ -265,7 +265,8 @@
                    :service :service/api
                    :request :create-forecast-version
                    :args forecast
-                   :context result-ch}))
+                   :context result-ch
+                   :timeout 20000}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/cljs/witan/ui/strings.cljs
+++ b/src/cljs/witan/ui/strings.cljs
@@ -74,6 +74,7 @@
    :creating-forecast              "Please wait whilst we update this forecast..."
    :today                          "Today"
    :yesterday                      "Yesterday"
+   :missing-required-inputs        "Some inputs are still missing data. Before you can save this forecast, please select or upload appropriate data for the corresponding inputs."
    })
 
 (defn get-string


### PR DESCRIPTION
Whilst on the forecast page we juggle three different data sources which can dictate the inputs - the current forecast, the "edited" forecast (which is a carbon copy of the current forecast, but with adjustments made) and the model. The listed inputs on either of the forecasts can actually accumulate to be less than what the model expects, in the case where we have 'default' inputs. The code was a bit ropey and wasn't showing these defaults if the forecast had omitted them (because it's totally valid to do so), so this is now all straightened out.
