### PR TITLE
Fix inputs stage behaviour when selecting data items

### DIFF
--- a/src/cljs/witan/ui/fixtures/forecast/view_model.cljs
+++ b/src/cljs/witan/ui/fixtures/forecast/view_model.cljs
@@ -150,18 +150,32 @@
   [owner _ item cursor]
   (om/update! cursor :selected-data-item item))
 
+(defn is-new-input?
+  [new-data forecast]
+  (let [category    (:data/category new-data)
+        data-id     (:data/data-id new-data)
+        existing-id (some #(if (= (:category %) category) (-> % :selected :data-id)) (:forecast/inputs forecast))
+        result      (not= data-id existing-id)]
+    (log/debug "1" data-id "2" existing-id result (:forecast/inputs forecast))
+    result))
+
 (defmethod event-handler
   :select-input
   [owner _ _ cursor]
   (let [category        (-> @cursor :browsing-input :category)
-        edited-forecast (or (:edited-forecast @cursor) (:forecast @cursor))
-        input-entry     (hash-map :category category :selected (util/map-remove-ns (assoc (:selected-data-item @cursor) :edited? true)))
-        model-inputs    (-> @cursor :model :model/input-data)
-        inputs          (util/squash-maps model-inputs (:forecast/inputs edited-forecast) :category)
-        inputs-ex       (util/squash-maps inputs [input-entry] :category)
-        with-input      (assoc edited-forecast :forecast/inputs inputs-ex)]
-    (om/update! cursor :edited-forecast with-input)
-    (update-required-inputs! cursor)
+        new-data        (:selected-data-item @cursor)
+        forecast        (:forecast @cursor)
+        other-forecast  (:edited-forecast @cursor)]
+    (if (is-new-input? new-data forecast)
+      (let [edited-forecast (or other-forecast forecast)
+            input-entry     (hash-map :category category :selected (util/map-remove-ns (assoc new-data :edited? true)))
+            model-inputs    (-> @cursor :model :model/input-data)
+            inputs          (util/squash-maps model-inputs (:forecast/inputs edited-forecast) :category)
+            inputs-ex       (util/squash-maps inputs [input-entry] :category)
+            with-input      (assoc edited-forecast :forecast/inputs inputs-ex)]
+        (om/update! cursor :edited-forecast with-input)
+        (update-required-inputs! cursor))
+      (comment (when other-forecast )))
     (event-handler owner :toggle-browse-input nil cursor)))
 
 (defmethod event-handler

--- a/src/cljs/witan/ui/fixtures/forecast/view_model.cljs
+++ b/src/cljs/witan/ui/fixtures/forecast/view_model.cljs
@@ -177,8 +177,7 @@
     (if (some->> inputs-ex
                  (map second)
                  (map val)
-                 (map :edited?)
-                 (some true?))
+                 (some :edited?))
       (om/update! cursor :edited-forecast with-input)
       (om/update! cursor :edited-forecast nil)))
     (update-required-inputs! cursor)


### PR DESCRIPTION
There were a couple of bugs surrounding this; namely, you could select the default or existing data item and the UI would act as if it were a change.
