### PR TITLE
Added `public?` to transmitted keys

### DIFF
--- a/src/cljs/witan/ui/services/api.cljs
+++ b/src/cljs/witan/ui/services/api.cljs
@@ -144,7 +144,7 @@
   :create-forecast-version
   [event forecast result-ch]
   (let [inputs (hash-map :inputs (into {} (map (fn [{:keys [category selected]}]
-                                                 (let [selected-req (select-keys selected [:file-name :name :s3-key])]
+                                                 (let [selected-req (select-keys selected [:file-name :name :s3-key :public?])]
                                                    (when (not-empty selected-req)
                                                      (hash-map category selected-req))))
                                                (:forecast/inputs forecast))))]

--- a/src/cljs/witan/ui/services/data.cljs
+++ b/src/cljs/witan/ui/services/data.cljs
@@ -267,7 +267,7 @@
 (defmethod request-handler
   :add-forecast-version
   [owner event forecast result-ch]
-  (log/info "Creating a new version of forecast " (:name forecast))
+  (log/info "Creating a new version of forecast " (:forecast/name forecast))
   (venue/request! {:owner owner
                    :service :service/api
                    :request :create-forecast-version


### PR DESCRIPTION
This fixes the 422 when trying to update a forecast (because the `public?` key was missing)
