### PR TITLE
You can now tag uploaded data as 'public'

### DIFF
--- a/src/cljs/witan/ui/fixtures/forecast/input_view.cljs
+++ b/src/cljs/witan/ui/fixtures/forecast/input_view.cljs
@@ -40,7 +40,8 @@
                          upload-error?
                          upload-success?
                          last-upload-filename
-                         data-items]} cursor]
+                         data-items]} cursor
+                         public-forecast? (-> @cursor :forecast :forecast/public?)]
              [:div.container
               [:h3 {:key "subtitle"}
                (get-string :upload-new-data)]
@@ -104,7 +105,13 @@
                    :on-submit (fn [e]
                                 (let [node (om/get-node owner "upload-data-name")
                                       idx (.-selectedIndex node) ;; if it has a selectedIndex it's a select input
-                                      result (if idx (.-value (aget (.-options node) idx)) (.-value node))]
+                                      name (if idx (.-value (aget (.-options node) idx)) (.-value node))
+                                      result {:name name
+                                              :public? (if public-forecast?
+                                                         true
+                                                         (if idx
+                                                           (some #(if (= (:data/name %) name) (:data/public? %)) data-items)
+                                                           (.-checked (om/get-node owner "upload-data-public"))))}]
                                   (venue/raise! owner :upload-file result))
                                 (.preventDefault e))}
 
@@ -136,9 +143,11 @@
                                   [:input.full-width {:key "input"
                                                       :ref "upload-data-name"
                                                       :type "text"
-                                                      :required true}]])
-                     [:div.spacer
-                      {:key "spacer"}]
+                                                      :required true}]
+                                  (if-not public-forecast?
+                                    [:small {} [:input.pure-input {:type "checkbox"
+                                                                   :ref "upload-data-public"}] " " (get-string :upload-data-public-explain)])])
+
                      [:button.pure-button.button-primary.upload-button {:key "button"} (get-string :upload)]]
 
                     ;;;;;;;;;;;;;;;

--- a/src/cljs/witan/ui/fixtures/forecast/view_model.cljs
+++ b/src/cljs/witan/ui/fixtures/forecast/view_model.cljs
@@ -116,17 +116,18 @@
 
 (defmethod event-handler
   :upload-file
-  [owner _ data-item-name cursor]
+  [owner _ {:keys [name public?]} cursor]
   (log/info "Starting upload...")
   (om/update! cursor :uploading? true)
-  (om/update! cursor :last-upload-filename data-item-name)
+  (om/update! cursor :last-upload-filename name)
   (venue/request! {:owner   owner
                    :service :service/data
                    :request :upload-data
                    :args    {:category (-> @cursor :browsing-input :category)
                              :file     (:upload-file @cursor)
                              :filename (:upload-filename @cursor)
-                             :name     data-item-name
+                             :name     name
+                             :public?  public?
                              :id       (:id @cursor)
                              :version  (:version @cursor)}
                    :context cursor

--- a/src/cljs/witan/ui/services/data.cljs
+++ b/src/cljs/witan/ui/services/data.cljs
@@ -382,6 +382,7 @@
         data-item {:category  category
                    :name      name
                    :file-name (-> context :args :filename)
+                   :public?   (-> context :args :public?)
                    :s3-key    s3-key
                    :created   (tf/unparse (tf/formatters :date-hour-minute-second) (t/now))
                    :version   version

--- a/src/cljs/witan/ui/strings.cljs
+++ b/src/cljs/witan/ui/strings.cljs
@@ -87,6 +87,7 @@
    :superseded                     "Superseded"
    :use-data-item                  "Use"
    :public                         "Public"
+   :upload-data-public-explain     "Tick this box to make the data visible to everyone (public)"
 
    })
 


### PR DESCRIPTION
Public projections will automatically have their uploaded data set to public. Private forecasts display a checkbox on the upload dialog which allows the uploader to make this data public.
