### PR TITLE
Add a warning for public forecasts

### DIFF
--- a/src/cljs/witan/ui/fixtures/forecast/input_view.cljs
+++ b/src/cljs/witan/ui/fixtures/forecast/input_view.cljs
@@ -144,7 +144,8 @@
                                                       :ref "upload-data-name"
                                                       :type "text"
                                                       :required true}]
-                                  (if-not public-forecast?
+                                  (if public-forecast?
+                                    [:small (get-string :upload-data-public-warning)]
                                     [:small {} [:input.pure-input {:type "checkbox"
                                                                    :ref "upload-data-public"}] " " (get-string :upload-data-public-explain)])])
 

--- a/src/cljs/witan/ui/strings.cljs
+++ b/src/cljs/witan/ui/strings.cljs
@@ -88,6 +88,7 @@
    :use-data-item                  "Use"
    :public                         "Public"
    :upload-data-public-explain     "Tick this box to make the data visible to everyone (public)"
+   :upload-data-public-warning     "As this is a public projection, any data you upload will also become public."
 
    })
 


### PR DESCRIPTION
It explains that any data uploaded into this projection will be public
