### PR TITLE
Deploy using only domain names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ WORKDIR /etc/nginx
 # env var
 ARG NGINX_SERVER_ADDR
 ENV NGINX_SERVER_ADDR $NGINX_SERVER_ADDR
+ARG DEPLOY_ADDR
+ENV DEPLOY_ADDR $DEPLOY_ADDR
 
 # move over files
 ADD target/build/ /var/www/witan-ui

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ deployment:
     tag: /release-.*/
     commands:
       - ./build_prod.sh
-      - docker build --build-arg NGINX_SERVER_ADDR=$NGINX_SERVER_ADDR -t mastodonc/witan.ui .
+      - docker build --build-arg NGINX_SERVER_ADDR=$NGINX_SERVER_ADDR --build-arg DEPLOY_ADDR=$DEPLOY_ADDR -t mastodonc/witan.ui .
       - docker tag -f mastodonc/witan.ui mastodonc/witan.ui:latest
       - docker tag -f mastodonc/witan.ui mastodonc/witan.ui:git-$(echo $CIRCLE_SHA1 | cut -c1-12)
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS

--- a/deploy_staging.sh
+++ b/deploy_staging.sh
@@ -5,7 +5,7 @@ TAG=git-$(echo $CIRCLE_SHA1 | cut -c1-12)
 sed "s/@@TAG@@/$TAG/" witan-ui.json.template > witan-ui.json
 
 # we want curl to output something we can use to indicate success/failure
-STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST http://$DEPLOY_IP:9501/marathon/witan-ui -H "Content-Type: application/json" -H "$SEKRIT_HEADER: 123" --data-binary "@witan-ui.json")
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST http://$DEPLOY_DOMAIN/deploy/marathon/witan-ui -H "Content-Type: application/json" -H "$SEKRIT_HEADER: 123" --data-binary "@witan-ui.json")
 echo "HTTP code " $STATUS
 if [ $STATUS == "201" ]
 then exit 0

--- a/start-nginx.sh
+++ b/start-nginx.sh
@@ -2,6 +2,8 @@
 
 SERVER_ADDR=${NGINX_SERVER_ADDR:?not set}
 SERVER_PORT=${NGINX_SERVER_PORT:-3000}
+DEPLOY_ADDR=${DEPLOY_IP:?not set}
+DEPLOY_PORT=${DEPLOY_PORT:-9501}
 
 PROXY_CONFIG_FILE=/etc/nginx/sites-available/witan-ui
 
@@ -31,21 +33,29 @@ server {
             access_log /var/log/nginx/elb_status_access.log;
             proxy_pass http://${SERVER_ADDR}:${SERVER_PORT};
         }
-        
+
         location ~* /api-docs/(.+) {
             real_ip_header X-Forwarded-For;
             set_real_ip_from 0.0.0.0/0;
 
             rewrite ^/api-docs/(.+)$ /\$1 break;
-            proxy_pass http://${SERVER_ADDR}:${SERVER_PORT};       
+            proxy_pass http://${SERVER_ADDR}:${SERVER_PORT};
         }
-        
+
+        location ~* /deploy/(.+) {
+            real_ip_header X-Forwarded-For;
+            set_real_ip_from 0.0.0.0/0;
+
+            rewrite ^/deploy/(.+)$ /\$1 break;
+            proxy_pass http://${DEPLOY_ADDR}:${DEPLOY_PORT};
+        }
+
         location /api-docs/ {
             real_ip_header X-Forwarded-For;
             set_real_ip_from 0.0.0.0/0;
             proxy_pass http://${SERVER_ADDR}:${SERVER_PORT}/index.html;
         }
-        
+
         location /swagger.json {
             real_ip_header X-Forwarded-For;
             set_real_ip_from 0.0.0.0/0;


### PR DESCRIPTION
- instead of using an ip address in the deploy, it points to witan-alpha.mastodonc.com/deploy/
- this then needs to be proxied to sebastopol.marathon.mesos on port 9501, so the nginx config is changed for that

Those changes are reflected in the CirleCI environment.
