### PR TITLE
nginx regexp changed to catch ‘’

### DIFF
--- a/start-nginx.sh
+++ b/start-nginx.sh
@@ -43,6 +43,7 @@ server {
         }
 
         location ~* /deploy/(.*) {
+            access_log /var/log/nginx/deploy_access.log;
             real_ip_header X-Forwarded-For;
             set_real_ip_from 0.0.0.0/0;
 

--- a/start-nginx.sh
+++ b/start-nginx.sh
@@ -42,11 +42,11 @@ server {
             proxy_pass http://${SERVER_ADDR}:${SERVER_PORT};
         }
 
-        location ~* /deploy/(.+) {
+        location ~* /deploy/(.*) {
             real_ip_header X-Forwarded-For;
             set_real_ip_from 0.0.0.0/0;
 
-            rewrite ^/deploy/(.+)$ /\$1 break;
+            rewrite ^/deploy/(.*)$ /\$1 break;
             proxy_pass http://${DEPLOY_ADDR}:${DEPLOY_PORT};
         }
 


### PR DESCRIPTION
the / path of sebastopol is a simple health check, so can be handy to be able to pass through to that path as well.
