### PR TITLE
Remove webfonts to to check missing letters bug

### DIFF
--- a/src/clj/witan/styles/base.clj
+++ b/src/clj/witan/styles/base.clj
@@ -291,6 +291,7 @@
       {:background-color colour/lighter-gray
        :box-shadow "0px 2px 4px #888888"
        :padding-top: (em 1)
+       :padding-bottom: (em 0.65)
        :position :relative
        :z-index 5}
       [:.pure-menu-list

--- a/src/clj/witan/styles/base.clj
+++ b/src/clj/witan/styles/base.clj
@@ -290,7 +290,7 @@
      [:.witan-page-heading
       {:background-color colour/lighter-gray
        :box-shadow "0px 2px 4px #888888"
-       :height (px 58)
+       :padding-top: (em 1)
        :position :relative
        :z-index 5}
       [:.pure-menu-list

--- a/src/clj/witan/styles/fonts.clj
+++ b/src/clj/witan/styles/fonts.clj
@@ -7,5 +7,5 @@
    (gs/at-font-face
     {:font-family "'Kadwa', serif"})])
 
-(def base-fonts  ["'Fira Sans'" "Helvetica Neue" "Helvetica" "Arial" "sans-serif"])
-(def title-fonts ["'Kadwa'" "Helvetica Neue" "Helvetica" "Arial" "sans-serif"])
+(def base-fonts  ["Helvetica Neue" "Helvetica" "Arial" "sans-serif"])
+(def title-fonts ["Helvetica Neue" "Helvetica" "Arial" "sans-serif"])


### PR DESCRIPTION
Remove the two Webfonts from `base-fonts` and `title-fonts`, to see if it has any affect on the missing letters issue reported by users on Firefox and Windows.
