### PR TITLE
Use clojure syntax, not CSS

### DIFF
--- a/src/clj/witan/styles/base.clj
+++ b/src/clj/witan/styles/base.clj
@@ -290,8 +290,8 @@
      [:.witan-page-heading
       {:background-color colour/lighter-gray
        :box-shadow "0px 2px 4px #888888"
-       :padding-top: (em 1)
-       :padding-bottom: (em 0.65)
+       :padding-top (em 1)
+       :padding-bottom (em 0.65)
        :position :relative
        :z-index 5}
       [:.pure-menu-list


### PR DESCRIPTION
This should resolve an embarrassing syntax mismatch where I put at the `:` both ends of a clojure keyword.

Sorry about that.
