### PR TITLE
json logs for nginx posted to docker logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,12 @@ ENV NGINX_SERVER_ADDR $NGINX_SERVER_ADDR
 
 # move over files
 ADD target/build/ /var/www/witan-ui
+ADD log-format.conf /etc/nginx/conf.d/log-format.conf
 ADD start-nginx.sh /start-nginx
+
+# have the nginx log be piped to stdout
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log
 
 # Define default command.
 CMD ["/bin/bash","/start-nginx"]

--- a/log-format.conf
+++ b/log-format.conf
@@ -1,0 +1,11 @@
+log_format logstash_json '{ "@timestamp": "$time_iso8601", '
+                            '"@fields": { '
+                            '"remote_addr": "$remote_addr", '
+                            '"remote_user": "$remote_user", '
+                            '"body_bytes_sent": "$body_bytes_sent", '
+                            '"request_time": "$request_time", '
+                            '"status": "$status", '
+                            '"request": "$request", '
+                            '"request_method": "$request_method", '
+                            '"http_referrer": "$http_referer", '
+                            '"http_user_agent": "$http_user_agent" } }';

--- a/start-nginx.sh
+++ b/start-nginx.sh
@@ -17,7 +17,7 @@ server {
         server_name witan-ui;
 
         location /api {
-            access_log /var/log/nginx/access.log;
+            access_log /var/log/nginx/access.log logstash_json;
 
             # Assumes we are already behind a reverse proxy (e.g. ELB)
             real_ip_header X-Forwarded-For;


### PR DESCRIPTION
json logs are more useful in the ELK context (better searchability on elasticsearch)
